### PR TITLE
fix: sync initial grid size between reference and drawing panels

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -22,6 +22,8 @@ interface DrawingCanvasProps {
   grid: GridSettings
   guideLines: readonly GuideLine[]
   guideVersion: number
+  /** If provided, initialize view transform to fit this size (match reference panel scale) */
+  fitSize?: { width: number; height: number }
 }
 
 const ERASER_THRESHOLD = 20
@@ -38,6 +40,7 @@ export function DrawingCanvas({
   grid,
   guideLines,
   guideVersion,
+  fitSize,
 }: DrawingCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -96,12 +99,26 @@ export function DrawingCanvas({
     const cssHeight = canvas.height / dpr
     const topLeft = viewTransformRef.current.screenToCanvas(0, 0)
     const bottomRight = viewTransformRef.current.screenToCanvas(cssWidth, cssHeight)
-    drawGrid(ctx, grid, topLeft, bottomRight, vt.scale)
+    const gridCenter = fitSize ? { x: fitSize.width / 2, y: fitSize.height / 2 } : undefined
+    drawGrid(ctx, grid, topLeft, bottomRight, vt.scale, gridCenter)
     drawGuideLines(ctx, guideLines, vt.scale)
 
     // Reset to DPR-only transform
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-  }, [highlightedStrokeIndex, strokeManagerRef, grid, guideLines])
+  }, [highlightedStrokeIndex, strokeManagerRef, grid, guideLines, fitSize])
+
+  const fitToSize = useCallback(() => {
+    const container = containerRef.current
+    if (!container || !fitSize) return
+    const rect = container.getBoundingClientRect()
+    const scaleX = rect.width / fitSize.width
+    const scaleY = rect.height / fitSize.height
+    const scale = Math.min(scaleX, scaleY)
+    const offsetX = (rect.width - fitSize.width * scale) / 2
+    const offsetY = (rect.height - fitSize.height * scale) / 2
+    viewTransformRef.current.reset()
+    viewTransformRef.current.applyPinch(0, 0, scale, offsetX, offsetY)
+  }, [fitSize])
 
   // Setup canvas with DPR
   const setupCanvas = useCallback(() => {
@@ -143,10 +160,22 @@ export function DrawingCanvas({
   // Reset view when viewResetVersion changes
   useEffect(() => {
     if (viewResetVersion > 0) {
-      viewTransformRef.current.reset()
+      if (fitSize) {
+        fitToSize()
+      } else {
+        viewTransformRef.current.reset()
+      }
       redrawAll()
     }
-  }, [viewResetVersion, redrawAll])
+  }, [viewResetVersion, redrawAll, fitSize, fitToSize])
+
+  // Re-fit when fitSize changes
+  useEffect(() => {
+    if (fitSize) {
+      fitToSize()
+      redrawAll()
+    }
+  }, [fitSize, fitToSize, redrawAll])
 
   const getCanvasPoint = useCallback((clientX: number, clientY: number): Point => {
     const canvas = canvasRef.current!

--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -12,9 +12,10 @@ import type { Stroke } from '../drawing/types'
 interface DrawingPanelProps {
   onOverlayStrokes?: (strokes: readonly Stroke[] | null) => void
   referenceInfo?: string
+  referenceSize?: { width: number; height: number } | null
 }
 
-export function DrawingPanel({ onOverlayStrokes, referenceInfo = '' }: DrawingPanelProps) {
+export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSize }: DrawingPanelProps) {
   const strokeManagerRef = useRef(new StrokeManager())
   const [mode, setMode] = useState<DrawingMode>('pen')
   const [highlightedStrokeIndex, setHighlightedStrokeIndex] = useState<number | null>(null)
@@ -275,7 +276,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '' }: DrawingPa
           grid={grid}
           guideLines={lines}
           guideVersion={guideVersion}
-
+          fitSize={referenceSize ?? undefined}
         />
       </Box>
 

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -13,12 +13,14 @@ interface ImageViewerProps {
   guideVersion: number
   /** Overlay strokes from the drawing panel */
   overlayStrokes?: readonly Stroke[]
+  /** Called when image is loaded with its natural dimensions */
+  onImageLoaded?: (width: number, height: number) => void
 }
 
 const TRACKPAD_ZOOM_SPEED = 0.01
 const OVERLAY_COLOR = 'rgba(0, 0, 255, 0.4)'
 
-export function ImageViewer({ imageUrl, viewResetVersion, grid, guideLines, guideVersion, overlayStrokes }: ImageViewerProps) {
+export function ImageViewer({ imageUrl, viewResetVersion, grid, guideLines, guideVersion, overlayStrokes, onImageLoaded }: ImageViewerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const viewTransformRef = useRef(new ViewTransform())
@@ -52,7 +54,8 @@ export function ImageViewer({ imageUrl, viewResetVersion, grid, guideLines, guid
     const cssHeight = canvas.height / dpr
     const topLeft = viewTransformRef.current.screenToCanvas(0, 0)
     const bottomRight = viewTransformRef.current.screenToCanvas(cssWidth, cssHeight)
-    drawGrid(ctx, grid, topLeft, bottomRight, vt.scale)
+    const imgCenter = img ? { x: img.naturalWidth / 2, y: img.naturalHeight / 2 } : undefined
+    drawGrid(ctx, grid, topLeft, bottomRight, vt.scale, imgCenter)
     drawGuideLines(ctx, guideLines, vt.scale)
 
     // Draw overlay strokes in canvas coordinate space (same grid coordinates as drawing panel)
@@ -116,10 +119,11 @@ export function ImageViewer({ imageUrl, viewResetVersion, grid, guideLines, guid
     const img = new Image()
     img.onload = () => {
       imageRef.current = img
+      onImageLoaded?.(img.naturalWidth, img.naturalHeight)
       fitImage()
     }
     img.src = imageUrl
-  }, [imageUrl, fitImage])
+  }, [imageUrl, fitImage, onImageLoaded])
 
   // ResizeObserver
   useEffect(() => {

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -10,9 +10,10 @@ type ReferenceMode = 'browse' | 'fixed'
 
 interface ReferencePanelProps {
   overlayStrokes?: readonly Stroke[] | null
+  onReferenceImageSize?: (width: number, height: number) => void
 }
 
-export function ReferencePanel({ overlayStrokes }: ReferencePanelProps) {
+export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: ReferencePanelProps) {
   const { grid, lines, version: guideVersion, toggleGrid } = useGuides()
   const [source, setSource] = useState<ReferenceSource>('none')
   const [referenceMode, setReferenceMode] = useState<ReferenceMode>('browse')
@@ -131,6 +132,7 @@ export function ReferencePanel({ overlayStrokes }: ReferencePanelProps) {
             guideLines={lines}
             guideVersion={guideVersion}
             overlayStrokes={overlayStrokes ?? undefined}
+            onImageLoaded={onReferenceImageSize}
           />
         )}
       </Box>

--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -10,9 +10,14 @@ export function SplitLayout() {
   const orientation = useOrientation()
   const isLandscape = orientation === 'landscape'
   const [overlayStrokes, setOverlayStrokes] = useState<readonly Stroke[] | null>(null)
+  const [referenceSize, setReferenceSize] = useState<{ width: number; height: number } | null>(null)
 
   const handleOverlayStrokes = useCallback((strokes: readonly Stroke[] | null) => {
     setOverlayStrokes(strokes)
+  }, [])
+
+  const handleReferenceImageSize = useCallback((width: number, height: number) => {
+    setReferenceSize({ width, height })
   }, [])
 
   return (
@@ -27,10 +32,10 @@ export function SplitLayout() {
         }}
       >
         <Box sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
-          <ReferencePanel overlayStrokes={overlayStrokes} />
+          <ReferencePanel overlayStrokes={overlayStrokes} onReferenceImageSize={handleReferenceImageSize} />
         </Box>
         <Box sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
-          <DrawingPanel onOverlayStrokes={handleOverlayStrokes} />
+          <DrawingPanel onOverlayStrokes={handleOverlayStrokes} referenceSize={referenceSize} />
         </Box>
       </Box>
     </GuideProvider>

--- a/src/guides/drawGuides.ts
+++ b/src/guides/drawGuides.ts
@@ -1,7 +1,8 @@
 import type { GridSettings, GuideLine } from './types'
 import type { Point } from '../drawing/types'
 
-const GRID_COLOR = 'rgba(0, 150, 255, 0.15)'
+const GRID_COLOR = 'rgba(0, 150, 255, 0.35)'
+const GRID_ORIGIN_COLOR = 'rgba(0, 150, 255, 0.6)'
 const GUIDE_COLOR = 'rgba(255, 50, 50, 0.6)'
 const GUIDE_WIDTH = 1
 
@@ -10,19 +11,21 @@ const GUIDE_WIDTH = 1
  * The caller should have already applied the view transform to ctx.
  * visibleTopLeft/visibleBottomRight define the visible area in world coordinates.
  */
+/**
+ * Draw grid in canvas/world coordinate space.
+ * center: the grid line nearest to this point will be drawn as a thick center line.
+ */
 export function drawGrid(
   ctx: CanvasRenderingContext2D,
   grid: GridSettings,
   visibleTopLeft: Point,
   visibleBottomRight: Point,
   scale: number,
+  center?: Point,
 ): void {
   if (!grid.enabled || grid.spacing <= 0) return
 
   ctx.save()
-  ctx.strokeStyle = GRID_COLOR
-  // Keep grid line width constant on screen regardless of zoom
-  ctx.lineWidth = 1 / scale
 
   const spacing = grid.spacing
   const startX = Math.floor(visibleTopLeft.x / spacing) * spacing
@@ -30,8 +33,18 @@ export function drawGrid(
   const startY = Math.floor(visibleTopLeft.y / spacing) * spacing
   const endY = visibleBottomRight.y
 
+  const normalWidth = 1 / scale
+  const originWidth = 3 / scale
+
+  // Snap center to nearest grid line
+  const centerX = center ? Math.round(center.x / spacing) * spacing : null
+  const centerY = center ? Math.round(center.y / spacing) * spacing : null
+
   // Vertical lines
   for (let x = startX; x <= endX; x += spacing) {
+    const isCenter = centerX !== null && Math.abs(x - centerX) < spacing * 0.01
+    ctx.strokeStyle = isCenter ? GRID_ORIGIN_COLOR : GRID_COLOR
+    ctx.lineWidth = isCenter ? originWidth : normalWidth
     ctx.beginPath()
     ctx.moveTo(x, startY)
     ctx.lineTo(x, endY)
@@ -40,6 +53,9 @@ export function drawGrid(
 
   // Horizontal lines
   for (let y = startY; y <= endY; y += spacing) {
+    const isCenter = centerY !== null && Math.abs(y - centerY) < spacing * 0.01
+    ctx.strokeStyle = isCenter ? GRID_ORIGIN_COLOR : GRID_COLOR
+    ctx.lineWidth = isCenter ? originWidth : normalWidth
     ctx.beginPath()
     ctx.moveTo(startX, y)
     ctx.lineTo(endX, y)


### PR DESCRIPTION
## Summary
- お手本画像が読み込まれたとき、そのサイズをドロー画面に伝達
- ドロー画面が同じfit-to-containerスケールで初期化されるように変更
- これにより、角度固定直後の初期状態でグリッドが両画面で同じ間隔に表示される
- ズームリセットボタンもfitSizeを考慮するように修正
- グリッドの色を濃く変更（opacity 0.15→0.35）
- 画像中心に最も近いグリッド線を太く・濃く描画し、位置合わせの基準線として機能させる

## Test plan
- [ ] Sketchfabで角度を固定した後、グリッドONで両画面のグリッド間隔が一致することを確認
- [ ] ローカル画像読み込み時も同様に確認
- [ ] 中央付近のグリッド線が太く表示されることを確認
- [ ] ズームリセットボタンで初期状態に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)