### PR TITLE
fix: separate concurrency groups for deploy and PR preview

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -8,7 +8,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: gh-pages-deploy
+  group: pr-preview-cleanup
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,8 +83,8 @@ jobs:
     needs: [changes, build]
     runs-on: ubuntu-latest
     concurrency:
-      group: gh-pages-deploy
-      cancel-in-progress: false
+      group: pr-preview-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- PRマージ時にCleanup PR Previewが本番デプロイをキャンセルしていた問題を修正
- `gh-pages-deploy` concurrencyグループを3つに分離:
  - `gh-pages-deploy`: 本番デプロイのみ
  - `pr-preview-cleanup`: PRプレビュークリーンアップ
  - `pr-preview-{PR番号}`: PRプレビューデプロイ（PR単位で管理）

## Test plan
- [ ] PRをマージした後、本番デプロイがキャンセルされずに完了することを確認
- [ ] PRプレビューが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)