### PR TITLE
fix: iPad Safari viewport sizing and add fullscreen button

### DIFF
--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -28,7 +28,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
   const [showGallery, setShowGallery] = useState(false)
   const [saving, setSaving] = useState(false)
 
-  const { grid, lines, version: guideVersion, toggleGrid } = useGuides()
+  const { grid, lines, version: guideVersion } = useGuides()
   const timer = useTimer()
 
   const syncUndoRedoState = useCallback(() => {
@@ -125,6 +125,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
           minHeight: 40,
         }}
       >
+        {/* Drawing tools */}
         <Tooltip title="Pen">
           <IconButton
             size="small"
@@ -157,6 +158,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
 
         <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
 
+        {/* Edit */}
         <Tooltip title="Undo">
           <span>
             <IconButton size="small" onClick={handleUndo} disabled={!canUndo}>
@@ -173,8 +175,6 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
           </span>
         </Tooltip>
 
-        <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
-
         <Tooltip title="Clear all &amp; reset timer">
           <span>
             <IconButton size="small" onClick={handleClear} disabled={strokeCount === 0}>
@@ -183,22 +183,9 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
           </span>
         </Tooltip>
 
-        <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
+        <Box sx={{ flex: 1 }} />
 
-        <Tooltip title="Toggle grid">
-          <IconButton
-            size="small"
-            onClick={toggleGrid}
-            sx={{
-              bgcolor: grid.enabled ? 'info.main' : 'transparent',
-              color: grid.enabled ? 'white' : 'inherit',
-              '&:hover': { bgcolor: grid.enabled ? 'info.dark' : 'action.hover' },
-            }}
-          >
-            #
-          </IconButton>
-        </Tooltip>
-
+        {/* View & compare */}
         <Tooltip title="Compare with reference">
           <IconButton
             size="small"
@@ -220,8 +207,9 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
           </IconButton>
         </Tooltip>
 
-        {/* Timer */}
-        <Box sx={{ flex: 1 }} />
+        <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
+
+        {/* Timer & data */}
         <Typography
           variant="body2"
           sx={{

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Tooltip, IconButton } from '@mui/material'
 import { SketchfabViewer } from './SketchfabViewer'
 import { ImageViewer } from './ImageViewer'
 import { useGuides } from '../guides/useGuides'
+import { useFullscreen } from '../hooks/useFullscreen'
 import type { Stroke } from '../drawing/types'
 
 type ReferenceSource = 'none' | 'sketchfab' | 'image'
@@ -15,6 +16,7 @@ interface ReferencePanelProps {
 
 export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: ReferencePanelProps) {
   const { grid, lines, version: guideVersion, toggleGrid } = useGuides()
+  const { isFullscreen, toggleFullscreen, isSupported: fullscreenSupported } = useFullscreen()
   const [source, setSource] = useState<ReferenceSource>('none')
   const [referenceMode, setReferenceMode] = useState<ReferenceMode>('browse')
   const [fixedImageUrl, setFixedImageUrl] = useState<string | null>(null)
@@ -71,6 +73,7 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
           minHeight: 40,
         }}
       >
+        {/* Source selection */}
         <Button size="small" variant={source === 'sketchfab' ? 'contained' : 'outlined'} onClick={handleOpenSketchfab}>
           Sketchfab
         </Button>
@@ -79,16 +82,14 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
         </Button>
 
         {source === 'sketchfab' && referenceMode === 'fixed' && (
-          <>
-            <Box sx={{ flex: 1 }} />
-            <Button size="small" variant="outlined" onClick={handleChangeAngle}>
-              Change Angle
-            </Button>
-          </>
+          <Button size="small" variant="outlined" onClick={handleChangeAngle}>
+            Change Angle
+          </Button>
         )}
 
-        <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
+        <Box sx={{ flex: 1 }} />
 
+        {/* View controls */}
         <Tooltip title="Toggle grid">
           <IconButton
             size="small"
@@ -107,6 +108,14 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
           <Tooltip title="Reset zoom">
             <IconButton size="small" onClick={() => setViewResetVersion(v => v + 1)}>
               &#8858;
+            </IconButton>
+          </Tooltip>
+        )}
+
+        {fullscreenSupported && (
+          <Tooltip title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}>
+            <IconButton size="small" onClick={toggleFullscreen}>
+              {isFullscreen ? '\u2716' : '\u26F6'}
             </IconButton>
           </Tooltip>
         )}

--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -27,7 +27,7 @@ export function SplitLayout() {
           display: 'flex',
           flexDirection: isLandscape ? 'row' : 'column',
           width: '100vw',
-          height: '100vh',
+          height: '100dvh',
           overflow: 'hidden',
         }}
       >

--- a/src/hooks/useFullscreen.ts
+++ b/src/hooks/useFullscreen.ts
@@ -1,0 +1,25 @@
+import { useState, useCallback, useEffect } from 'react'
+
+export function useFullscreen() {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  useEffect(() => {
+    const handleChange = () => {
+      setIsFullscreen(!!document.fullscreenElement)
+    }
+    document.addEventListener('fullscreenchange', handleChange)
+    return () => document.removeEventListener('fullscreenchange', handleChange)
+  }, [])
+
+  const toggleFullscreen = useCallback(async () => {
+    if (document.fullscreenElement) {
+      await document.exitFullscreen()
+    } else {
+      await document.documentElement.requestFullscreen()
+    }
+  }, [])
+
+  const isSupported = !!document.documentElement.requestFullscreen
+
+  return { isFullscreen, toggleFullscreen, isSupported }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
 
 html, body, #root {
   width: 100%;
-  height: 100%;
+  height: 100dvh;
   overflow: hidden;
   touch-action: none;
 }


### PR DESCRIPTION
## Summary
- `100vh` → `100dvh` に変更し、iPad Safariの動的ツールバー分を考慮してビューポートを正しく計算
- Reference Panelツールバーに全画面切替ボタンを追加（Fullscreen API対応ブラウザのみ表示）
- 両パネルのツールバーボタン配置を整理:
  - Reference: `[Sketchfab] [Image] (Change Angle) ... [#Grid] [⊚Zoom] [⛶Full]`
  - Drawing: `[✎Pen] [⌫Eraser] | [↶Undo] [↷Redo] [🗑Clear] ... [⚙Compare] [⊚Zoom] | 0:00 [💾] [🖼]`
  - Gridボタンはお手本側のみに集約（両画面同期のため）
  - 全画面ボタンの重なり問題を解消

## Test plan
- [ ] iPad Safariで下部がはみ出さず、全コンテンツにアクセスできることを確認
- [ ] 全画面ボタンで全画面モードに入れることを確認
- [ ] Gridボタンがお手本側のみで、両画面に反映されることを確認
- [ ] ボタン同士の重なりがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)