### PR TITLE
feat: add guide line drawing UI on reference panel

### DIFF
--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -1,9 +1,11 @@
-import { useRef, useEffect, useCallback } from 'react'
+import { useRef, useEffect, useCallback, useState } from 'react'
 import { Box } from '@mui/material'
 import { ViewTransform } from '../drawing/ViewTransform'
 import { drawGrid, drawGuideLines } from '../guides/drawGuides'
 import type { GridSettings, GuideLine } from '../guides/types'
-import type { Stroke } from '../drawing/types'
+import type { Stroke, Point } from '../drawing/types'
+
+export type GuideInteractionMode = 'none' | 'add' | 'delete'
 
 interface ImageViewerProps {
   imageUrl: string
@@ -11,21 +13,44 @@ interface ImageViewerProps {
   grid: GridSettings
   guideLines: readonly GuideLine[]
   guideVersion: number
-  /** Overlay strokes from the drawing panel */
   overlayStrokes?: readonly Stroke[]
-  /** Called when image is loaded with its natural dimensions */
   onImageLoaded?: (width: number, height: number) => void
+  /** Guide line interaction mode */
+  guideMode: GuideInteractionMode
+  onAddGuideLine?: (x1: number, y1: number, x2: number, y2: number) => void
+  onDeleteGuideLine?: (id: string) => void
+  /** ID of the guide line currently highlighted for deletion */
+  highlightedGuideId?: string | null
+  onHighlightGuide?: (id: string | null) => void
 }
 
 const TRACKPAD_ZOOM_SPEED = 0.01
 const OVERLAY_COLOR = 'rgba(0, 0, 255, 0.4)'
+const GUIDE_HIT_THRESHOLD = 15
 
-export function ImageViewer({ imageUrl, viewResetVersion, grid, guideLines, guideVersion, overlayStrokes, onImageLoaded }: ImageViewerProps) {
+export function ImageViewer({
+  imageUrl, viewResetVersion, grid, guideLines, guideVersion,
+  overlayStrokes, onImageLoaded,
+  guideMode, onAddGuideLine,
+  highlightedGuideId, onHighlightGuide,
+}: ImageViewerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const viewTransformRef = useRef(new ViewTransform())
   const imageRef = useRef<HTMLImageElement | null>(null)
   const rafIdRef = useRef<number>(0)
+
+  // Guide line drawing state
+  const [dragStart, setDragStart] = useState<Point | null>(null)
+  const [dragEnd, setDragEnd] = useState<Point | null>(null)
+
+  const getCanvasPoint = useCallback((clientX: number, clientY: number): Point => {
+    const canvas = canvasRef.current!
+    const rect = canvas.getBoundingClientRect()
+    const screenX = clientX - rect.left
+    const screenY = clientY - rect.top
+    return viewTransformRef.current.screenToCanvas(screenX, screenY)
+  }, [])
 
   const redraw = useCallback(() => {
     const canvas = canvasRef.current
@@ -54,11 +79,23 @@ export function ImageViewer({ imageUrl, viewResetVersion, grid, guideLines, guid
     const cssHeight = canvas.height / dpr
     const topLeft = viewTransformRef.current.screenToCanvas(0, 0)
     const bottomRight = viewTransformRef.current.screenToCanvas(cssWidth, cssHeight)
-    const imgCenter = img ? { x: img.naturalWidth / 2, y: img.naturalHeight / 2 } : undefined
+    const imgCenter = { x: img.naturalWidth / 2, y: img.naturalHeight / 2 }
     drawGrid(ctx, grid, topLeft, bottomRight, vt.scale, imgCenter)
-    drawGuideLines(ctx, guideLines, vt.scale)
+    drawGuideLines(ctx, guideLines, vt.scale, highlightedGuideId)
 
-    // Draw overlay strokes in canvas coordinate space (same grid coordinates as drawing panel)
+    // Draw in-progress guide line
+    if (dragStart && dragEnd) {
+      ctx.strokeStyle = 'rgba(255, 50, 50, 0.8)'
+      ctx.lineWidth = 1.5 / vt.scale
+      ctx.setLineDash([6 / vt.scale, 4 / vt.scale])
+      ctx.beginPath()
+      ctx.moveTo(dragStart.x, dragStart.y)
+      ctx.lineTo(dragEnd.x, dragEnd.y)
+      ctx.stroke()
+      ctx.setLineDash([])
+    }
+
+    // Draw overlay strokes
     if (overlayStrokes && overlayStrokes.length > 0) {
       ctx.strokeStyle = OVERLAY_COLOR
       ctx.lineWidth = 2 / vt.scale
@@ -75,9 +112,8 @@ export function ImageViewer({ imageUrl, viewResetVersion, grid, guideLines, guid
       }
     }
 
-    // Reset to DPR-only transform
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-  }, [grid, guideLines, overlayStrokes])
+  }, [grid, guideLines, overlayStrokes, highlightedGuideId, dragStart, dragEnd])
 
   const requestRedraw = useCallback(() => {
     if (rafIdRef.current) return
@@ -129,19 +165,14 @@ export function ImageViewer({ imageUrl, viewResetVersion, grid, guideLines, guid
   useEffect(() => {
     const container = containerRef.current
     if (!container) return
-
-    const observer = new ResizeObserver(() => {
-      fitImage()
-    })
+    const observer = new ResizeObserver(() => fitImage())
     observer.observe(container)
     return () => observer.disconnect()
   }, [fitImage])
 
   // Reset view
   useEffect(() => {
-    if (viewResetVersion > 0) {
-      fitImage()
-    }
+    if (viewResetVersion > 0) fitImage()
   }, [viewResetVersion, fitImage])
 
   // Redraw when guides or overlay change
@@ -149,12 +180,13 @@ export function ImageViewer({ imageUrl, viewResetVersion, grid, guideLines, guid
     redraw()
   }, [guideVersion, overlayStrokes, redraw])
 
-  // Wheel zoom/pan
+  // Wheel zoom/pan (only when not in guide mode)
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
 
     const handleWheel = (e: WheelEvent) => {
+      if (guideMode !== 'none') return
       e.preventDefault()
       const rect = canvas.getBoundingClientRect()
       const focalX = e.clientX - rect.left
@@ -171,14 +203,132 @@ export function ImageViewer({ imageUrl, viewResetVersion, grid, guideLines, guid
 
     canvas.addEventListener('wheel', handleWheel, { passive: false })
     return () => canvas.removeEventListener('wheel', handleWheel)
-  }, [requestRedraw])
+  }, [requestRedraw, guideMode])
+
+  // Mouse handlers for guide line interaction
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (guideMode === 'none') return
+    const point = getCanvasPoint(e.clientX, e.clientY)
+
+    if (guideMode === 'add') {
+      setDragStart(point)
+      setDragEnd(point)
+    } else if (guideMode === 'delete') {
+      // Find nearest guide line
+      const threshold = GUIDE_HIT_THRESHOLD / viewTransformRef.current.get().scale
+      let best: GuideLine | null = null
+      let bestDist = threshold
+      for (const line of guideLines) {
+        const dist = pointToSegmentDist(point, line)
+        if (dist < bestDist) {
+          bestDist = dist
+          best = line
+        }
+      }
+      onHighlightGuide?.(best?.id ?? null)
+    }
+  }, [guideMode, getCanvasPoint, guideLines, onHighlightGuide])
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (guideMode !== 'add' || !dragStart) return
+    setDragEnd(getCanvasPoint(e.clientX, e.clientY))
+    requestRedraw()
+  }, [guideMode, dragStart, getCanvasPoint, requestRedraw])
+
+  const handleMouseUp = useCallback(() => {
+    if (guideMode !== 'add' || !dragStart || !dragEnd) return
+    const dx = dragEnd.x - dragStart.x
+    const dy = dragEnd.y - dragStart.y
+    if (Math.sqrt(dx * dx + dy * dy) > 5 / viewTransformRef.current.get().scale) {
+      onAddGuideLine?.(dragStart.x, dragStart.y, dragEnd.x, dragEnd.y)
+    }
+    setDragStart(null)
+    setDragEnd(null)
+  }, [guideMode, dragStart, dragEnd, onAddGuideLine])
+
+  // Touch handlers for guide line interaction
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (guideMode === 'none') return
+    e.preventDefault()
+    const touch = e.changedTouches[0]
+    const point = getCanvasPoint(touch.clientX, touch.clientY)
+
+    if (guideMode === 'add') {
+      setDragStart(point)
+      setDragEnd(point)
+    } else if (guideMode === 'delete') {
+      const threshold = GUIDE_HIT_THRESHOLD / viewTransformRef.current.get().scale
+      let best: GuideLine | null = null
+      let bestDist = threshold
+      for (const line of guideLines) {
+        const dist = pointToSegmentDist(point, line)
+        if (dist < bestDist) {
+          bestDist = dist
+          best = line
+        }
+      }
+      onHighlightGuide?.(best?.id ?? null)
+    }
+  }, [guideMode, getCanvasPoint, guideLines, onHighlightGuide])
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (guideMode !== 'add' || !dragStart) return
+    e.preventDefault()
+    const touch = e.changedTouches[0]
+    setDragEnd(getCanvasPoint(touch.clientX, touch.clientY))
+    requestRedraw()
+  }, [guideMode, dragStart, getCanvasPoint, requestRedraw])
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (guideMode !== 'add' || !dragStart || !dragEnd) return
+    e.preventDefault()
+    const dx = dragEnd.x - dragStart.x
+    const dy = dragEnd.y - dragStart.y
+    if (Math.sqrt(dx * dx + dy * dy) > 5 / viewTransformRef.current.get().scale) {
+      onAddGuideLine?.(dragStart.x, dragStart.y, dragEnd.x, dragEnd.y)
+    }
+    setDragStart(null)
+    setDragEnd(null)
+  }, [guideMode, dragStart, dragEnd, onAddGuideLine])
+
+  const cursor = guideMode === 'add' ? 'crosshair' : guideMode === 'delete' ? 'pointer' : 'default'
 
   return (
     <Box ref={containerRef} sx={{ width: '100%', height: '100%' }}>
       <canvas
         ref={canvasRef}
-        style={{ display: 'block', width: '100%', height: '100%', touchAction: 'none' }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchEnd}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: '100%',
+          touchAction: guideMode !== 'none' ? 'none' : 'auto',
+          cursor,
+        }}
       />
     </Box>
   )
+}
+
+function pointToSegmentDist(p: Point, line: GuideLine): number {
+  const dx = line.x2 - line.x1
+  const dy = line.y2 - line.y1
+  const lenSq = dx * dx + dy * dy
+  if (lenSq === 0) {
+    const ex = p.x - line.x1
+    const ey = p.y - line.y1
+    return Math.sqrt(ex * ex + ey * ey)
+  }
+  let t = ((p.x - line.x1) * dx + (p.y - line.y1) * dy) / lenSq
+  t = Math.max(0, Math.min(1, t))
+  const cx = line.x1 + t * dx
+  const cy = line.y1 + t * dy
+  return Math.sqrt((p.x - cx) ** 2 + (p.y - cy) ** 2)
 }

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react'
 import { Box, Button, Tooltip, IconButton } from '@mui/material'
 import { SketchfabViewer } from './SketchfabViewer'
-import { ImageViewer } from './ImageViewer'
+import { ImageViewer, type GuideInteractionMode } from './ImageViewer'
 import { useGuides } from '../guides/useGuides'
 import { useFullscreen } from '../hooks/useFullscreen'
 import type { Stroke } from '../drawing/types'
@@ -15,13 +15,15 @@ interface ReferencePanelProps {
 }
 
 export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: ReferencePanelProps) {
-  const { grid, lines, version: guideVersion, toggleGrid } = useGuides()
+  const { grid, lines, version: guideVersion, toggleGrid, addLine, removeLine, clearLines } = useGuides()
   const { isFullscreen, toggleFullscreen, isSupported: fullscreenSupported } = useFullscreen()
   const [source, setSource] = useState<ReferenceSource>('none')
   const [referenceMode, setReferenceMode] = useState<ReferenceMode>('browse')
   const [fixedImageUrl, setFixedImageUrl] = useState<string | null>(null)
   const [localImageUrl, setLocalImageUrl] = useState<string | null>(null)
   const [viewResetVersion, setViewResetVersion] = useState(0)
+  const [guideMode, setGuideMode] = useState<GuideInteractionMode>('none')
+  const [highlightedGuideId, setHighlightedGuideId] = useState<string | null>(null)
 
   const handleLoadLocalImage = useCallback(() => {
     const input = document.createElement('input')
@@ -55,7 +57,28 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
     setLocalImageUrl(null)
   }, [])
 
+  const handleAddGuideLine = useCallback((x1: number, y1: number, x2: number, y2: number) => {
+    addLine(x1, y1, x2, y2)
+  }, [addLine])
+
+  const handleDeleteHighlighted = useCallback(() => {
+    if (highlightedGuideId) {
+      removeLine(highlightedGuideId)
+      setHighlightedGuideId(null)
+    }
+  }, [highlightedGuideId, removeLine])
+
+  const handleCancelHighlight = useCallback(() => {
+    setHighlightedGuideId(null)
+  }, [])
+
+  const toggleGuideMode = useCallback((mode: GuideInteractionMode) => {
+    setGuideMode(prev => prev === mode ? 'none' : mode)
+    setHighlightedGuideId(null)
+  }, [])
+
   const displayImageUrl = source === 'image' ? localImageUrl : fixedImageUrl
+  const showGuideTools = referenceMode === 'fixed' && displayImageUrl
 
   return (
     <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -89,6 +112,69 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
 
         <Box sx={{ flex: 1 }} />
 
+        {/* Guide line tools (only when image is fixed) */}
+        {showGuideTools && (
+          <>
+            <Tooltip title="Add guide line">
+              <IconButton
+                size="small"
+                onClick={() => toggleGuideMode('add')}
+                sx={{
+                  bgcolor: guideMode === 'add' ? 'error.main' : 'transparent',
+                  color: guideMode === 'add' ? 'white' : 'inherit',
+                  '&:hover': { bgcolor: guideMode === 'add' ? 'error.dark' : 'action.hover' },
+                }}
+              >
+                &#9999;
+              </IconButton>
+            </Tooltip>
+
+            <Tooltip title="Delete guide line">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={() => toggleGuideMode('delete')}
+                  disabled={lines.length === 0}
+                  sx={{
+                    bgcolor: guideMode === 'delete' ? 'error.main' : 'transparent',
+                    color: guideMode === 'delete' ? 'white' : 'inherit',
+                    '&:hover': { bgcolor: guideMode === 'delete' ? 'error.dark' : 'action.hover' },
+                  }}
+                >
+                  &#10060;
+                </IconButton>
+              </span>
+            </Tooltip>
+
+            <Tooltip title="Clear all guide lines">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={clearLines}
+                  disabled={lines.length === 0}
+                >
+                  &#128465;
+                </IconButton>
+              </span>
+            </Tooltip>
+
+            <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
+          </>
+        )}
+
+        {/* Delete confirmation */}
+        {highlightedGuideId && (
+          <>
+            <Button size="small" color="error" variant="contained" onClick={handleDeleteHighlighted}>
+              Delete
+            </Button>
+            <Button size="small" variant="outlined" onClick={handleCancelHighlight}>
+              Cancel
+            </Button>
+            <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
+          </>
+        )}
+
         {/* View controls */}
         <Tooltip title="Toggle grid">
           <IconButton
@@ -104,7 +190,7 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
           </IconButton>
         </Tooltip>
 
-        {(referenceMode === 'fixed' && displayImageUrl) && (
+        {showGuideTools && (
           <Tooltip title="Reset zoom">
             <IconButton size="small" onClick={() => setViewResetVersion(v => v + 1)}>
               &#8858;
@@ -142,6 +228,11 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
             guideVersion={guideVersion}
             overlayStrokes={overlayStrokes ?? undefined}
             onImageLoaded={onReferenceImageSize}
+            guideMode={guideMode}
+            onAddGuideLine={handleAddGuideLine}
+            onDeleteGuideLine={removeLine}
+            highlightedGuideId={highlightedGuideId}
+            onHighlightGuide={setHighlightedGuideId}
           />
         )}
       </Box>


### PR DESCRIPTION
## Summary
- お手本画面（画像固定時）に補助線の配置・削除UIを追加
- ツールバーに3つのボタン:
  - ✏ 補助線追加モード: ドラッグで線分を描画（破線プレビュー付き）
  - ❌ 補助線削除モード: 線をタップで選択→Delete/Cancelで確認削除
  - 🗑 全補助線クリア
- 補助線はキャンバス座標系で両パネルに同期表示
- 補助線モード中はズーム・パンを無効化
- マウス・タッチ両対応

## Test plan
- [ ] お手本画像固定後、✏ボタンでドラッグして補助線を引けることを確認
- [ ] 引いた補助線がドロー画面にも表示されることを確認
- [ ] ❌ボタンで補助線をタップ→削除できることを確認
- [ ] 🗑ボタンで全補助線がクリアされることを確認
- [ ] iPadタッチ操作で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)