### PR TITLE
feat: i18n support and fix Change Angle behavior

### DIFF
--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -7,6 +7,7 @@ import { useTimer, formatTime } from '../hooks/useTimer'
 import { saveDrawing } from '../storage'
 import { generateThumbnail } from '../storage/generateThumbnail'
 import { Gallery } from './Gallery'
+import { t } from '../i18n'
 import type { Stroke } from '../drawing/types'
 
 interface DrawingPanelProps {
@@ -132,7 +133,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
         }}
       >
         {/* Drawing tools */}
-        <Tooltip title="Pen">
+        <Tooltip title={t('pen')}>
           <IconButton
             size="small"
             onClick={() => { setMode('pen'); setHighlightedStrokeIndex(null) }}
@@ -147,7 +148,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
           </IconButton>
         </Tooltip>
 
-        <Tooltip title="Eraser">
+        <Tooltip title={t('eraser')}>
           <IconButton
             size="small"
             onClick={() => setMode('eraser')}
@@ -165,7 +166,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
         <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
 
         {/* Edit */}
-        <Tooltip title="Undo">
+        <Tooltip title={t('undo')}>
           <span>
             <IconButton size="small" onClick={handleUndo} disabled={!canUndo}>
               &#8630;
@@ -173,7 +174,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
           </span>
         </Tooltip>
 
-        <Tooltip title="Redo">
+        <Tooltip title={t('redo')}>
           <span>
             <IconButton size="small" onClick={handleRedo} disabled={!canRedo}>
               &#8631;
@@ -181,7 +182,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
           </span>
         </Tooltip>
 
-        <Tooltip title="Clear all &amp; reset timer">
+        <Tooltip title={t('clearAll')}>
           <span>
             <IconButton size="small" onClick={handleClear} disabled={strokeCount === 0}>
               &#128465;
@@ -192,7 +193,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
         <Box sx={{ flex: 1 }} />
 
         {/* View & compare */}
-        <Tooltip title="Compare with reference">
+        <Tooltip title={t('compare')}>
           <IconButton
             size="small"
             onClick={handleToggleOverlay}
@@ -206,7 +207,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
           </IconButton>
         </Tooltip>
 
-        <Tooltip title="Reset zoom">
+        <Tooltip title={t('resetZoom')}>
           <IconButton size="small" onClick={() => setViewResetVersion(v => v + 1)}>
             &#8858;
           </IconButton>
@@ -228,7 +229,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
           {formatTime(timer.elapsedMs)}
         </Typography>
 
-        <Tooltip title="Save drawing">
+        <Tooltip title={t('saveDrawing')}>
           <span>
             <IconButton size="small" onClick={handleSave} disabled={strokeCount === 0 || saving}>
               &#128190;
@@ -236,7 +237,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
           </span>
         </Tooltip>
 
-        <Tooltip title="Gallery">
+        <Tooltip title={t('gallery')}>
           <IconButton size="small" onClick={() => setShowGallery(true)}>
             &#128444;
           </IconButton>
@@ -247,10 +248,10 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
           <>
             <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
             <Button size="small" color="error" variant="contained" onClick={handleDeleteHighlighted}>
-              Delete
+              {t('delete')}
             </Button>
             <Button size="small" variant="outlined" onClick={handleCancelHighlight}>
-              Cancel
+              {t('cancel')}
             </Button>
           </>
         )}

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { Box, Typography, IconButton, Tooltip } from '@mui/material'
 import { getAllDrawings, deleteDrawing, type DrawingRecord } from '../storage'
 import { formatTime } from '../hooks/useTimer'
+import { t } from '../i18n'
 
 interface GalleryProps {
   onClose: () => void
@@ -28,7 +29,7 @@ export function Gallery({ onClose }: GalleryProps) {
   }, [])
 
   const formatDate = (date: Date) => {
-    return new Date(date).toLocaleDateString('ja-JP', {
+    return new Date(date).toLocaleDateString(undefined, {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
@@ -66,7 +67,7 @@ export function Gallery({ onClose }: GalleryProps) {
           borderBottom: '1px solid #ddd',
         }}>
           <Typography variant="h6" sx={{ flex: 1 }}>
-            Gallery ({drawings.length})
+            {t('galleryTitle')} ({drawings.length})
           </Typography>
           <IconButton onClick={onClose} size="small">
             &#10005;
@@ -76,11 +77,11 @@ export function Gallery({ onClose }: GalleryProps) {
         {/* Content */}
         <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>
           {loading && (
-            <Typography color="text.secondary">Loading...</Typography>
+            <Typography color="text.secondary">{t('loading')}</Typography>
           )}
 
           {!loading && drawings.length === 0 && (
-            <Typography color="text.secondary">No saved drawings yet.</Typography>
+            <Typography color="text.secondary">{t('noDrawings')}</Typography>
           )}
 
           {!loading && drawings.length > 0 && (
@@ -102,7 +103,7 @@ export function Gallery({ onClose }: GalleryProps) {
                   {drawing.thumbnail && (
                     <img
                       src={drawing.thumbnail}
-                      alt={`Drawing ${drawing.id}`}
+                      alt={`#${drawing.id}`}
                       style={{ width: '100%', height: 140, objectFit: 'contain', background: '#fafafa' }}
                     />
                   )}
@@ -114,7 +115,7 @@ export function Gallery({ onClose }: GalleryProps) {
                       {formatTime(drawing.elapsedMs)}
                       {drawing.referenceInfo && ` - ${drawing.referenceInfo}`}
                     </Typography>
-                    <Tooltip title="Delete">
+                    <Tooltip title={t('delete')}>
                       <IconButton
                         size="small"
                         onClick={() => drawing.id != null && handleDelete(drawing.id)}

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -4,6 +4,7 @@ import { SketchfabViewer } from './SketchfabViewer'
 import { ImageViewer, type GuideInteractionMode } from './ImageViewer'
 import { useGuides } from '../guides/useGuides'
 import { useFullscreen } from '../hooks/useFullscreen'
+import { t } from '../i18n'
 import type { Stroke } from '../drawing/types'
 
 type ReferenceSource = 'none' | 'sketchfab' | 'image'
@@ -98,15 +99,15 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
       >
         {/* Source selection */}
         <Button size="small" variant={source === 'sketchfab' ? 'contained' : 'outlined'} onClick={handleOpenSketchfab}>
-          Sketchfab
+          {t('sketchfab')}
         </Button>
         <Button size="small" variant={source === 'image' ? 'contained' : 'outlined'} onClick={handleLoadLocalImage}>
-          Image
+          {t('image')}
         </Button>
 
         {source === 'sketchfab' && referenceMode === 'fixed' && (
           <Button size="small" variant="outlined" onClick={handleChangeAngle}>
-            Change Angle
+            {t('changeAngle')}
           </Button>
         )}
 
@@ -115,7 +116,7 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
         {/* Guide line tools (only when image is fixed) */}
         {showGuideTools && (
           <>
-            <Tooltip title="Add guide line">
+            <Tooltip title={t('addGuideLine')}>
               <IconButton
                 size="small"
                 onClick={() => toggleGuideMode('add')}
@@ -129,7 +130,7 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
               </IconButton>
             </Tooltip>
 
-            <Tooltip title="Delete guide line">
+            <Tooltip title={t('deleteGuideLine')}>
               <span>
                 <IconButton
                   size="small"
@@ -146,7 +147,7 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
               </span>
             </Tooltip>
 
-            <Tooltip title="Clear all guide lines">
+            <Tooltip title={t('clearGuideLines')}>
               <span>
                 <IconButton
                   size="small"
@@ -166,17 +167,17 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
         {highlightedGuideId && (
           <>
             <Button size="small" color="error" variant="contained" onClick={handleDeleteHighlighted}>
-              Delete
+              {t('delete')}
             </Button>
             <Button size="small" variant="outlined" onClick={handleCancelHighlight}>
-              Cancel
+              {t('cancel')}
             </Button>
             <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
           </>
         )}
 
         {/* View controls */}
-        <Tooltip title="Toggle grid">
+        <Tooltip title={t('toggleGrid')}>
           <IconButton
             size="small"
             onClick={toggleGrid}
@@ -191,7 +192,7 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
         </Tooltip>
 
         {showGuideTools && (
-          <Tooltip title="Reset zoom">
+          <Tooltip title={t('resetZoom')}>
             <IconButton size="small" onClick={() => setViewResetVersion(v => v + 1)}>
               &#8858;
             </IconButton>
@@ -199,7 +200,7 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
         )}
 
         {fullscreenSupported && (
-          <Tooltip title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}>
+          <Tooltip title={isFullscreen ? t('exitFullscreen') : t('fullscreen')}>
             <IconButton size="small" onClick={toggleFullscreen}>
               {isFullscreen ? '\u2716' : '\u26F6'}
             </IconButton>
@@ -211,12 +212,14 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
       <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
         {source === 'none' && (
           <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: 'text.secondary' }}>
-            Select a reference source above
+            {t('selectReference')}
           </Box>
         )}
 
-        {source === 'sketchfab' && referenceMode === 'browse' && (
-          <SketchfabViewer onFixAngle={handleFixAngle} />
+        {source === 'sketchfab' && (
+          <Box sx={{ display: referenceMode === 'browse' ? 'contents' : 'none' }}>
+            <SketchfabViewer onFixAngle={handleFixAngle} />
+          </Box>
         )}
 
         {referenceMode === 'fixed' && displayImageUrl && (

--- a/src/components/SketchfabViewer.tsx
+++ b/src/components/SketchfabViewer.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { Box, Button, TextField, Typography } from '@mui/material'
+import { t } from '../i18n'
 
 interface SketchfabViewerProps {
   onFixAngle: (screenshotUrl: string) => void
@@ -39,13 +40,13 @@ interface SearchResult {
 }
 
 const SKETCHFAB_CATEGORIES = [
-  { slug: 'animals-pets', label: 'Animals' },
-  { slug: 'cars-vehicles', label: 'Vehicles' },
-  { slug: 'characters-creatures', label: 'Characters' },
-  { slug: 'food-drink', label: 'Food' },
-  { slug: 'furniture-home', label: 'Furniture' },
-  { slug: 'nature-plants', label: 'Plants' },
-  { slug: 'science-technology', label: 'Technology' },
+  { slug: 'animals-pets', labelKey: 'animals' as const },
+  { slug: 'cars-vehicles', labelKey: 'vehicles' as const },
+  { slug: 'characters-creatures', labelKey: 'characters' as const },
+  { slug: 'food-drink', labelKey: 'food' as const },
+  { slug: 'furniture-home', labelKey: 'furniture' as const },
+  { slug: 'nature-plants', labelKey: 'plants' as const },
+  { slug: 'science-technology', labelKey: 'technology' as const },
 ]
 
 interface ThumbnailImage {
@@ -119,7 +120,7 @@ export function SketchfabViewer({ onFixAngle }: SketchfabViewerProps) {
         })
       },
       error: () => {
-        setError('Failed to load model')
+        setError(t('failedLoadModel'))
         setLoading(false)
       },
       autostart: 1,
@@ -155,7 +156,7 @@ export function SketchfabViewer({ onFixAngle }: SketchfabViewerProps) {
 
     api.getScreenShot({ width: 1024, height: 1024 }, (err, result) => {
       if (err) {
-        setError('Failed to capture screenshot')
+        setError(t('failedScreenshot'))
         return
       }
       onFixAngle(result)
@@ -178,7 +179,7 @@ export function SketchfabViewer({ onFixAngle }: SketchfabViewerProps) {
       const data = await res.json()
       setSearchResults(parseSearchResults(data))
     } catch {
-      setError('Search failed. Try again.')
+      setError(t('searchFailed'))
     }
   }, [])
 
@@ -197,7 +198,7 @@ export function SketchfabViewer({ onFixAngle }: SketchfabViewerProps) {
       .then(data => {
         setSearchResults(parseSearchResults(data))
       })
-      .catch(() => setError('Failed to fetch models'))
+      .catch(() => setError(t('failedFetchModels')))
   }, [])
 
   const handleSelectModel = useCallback((uid: string) => {
@@ -225,18 +226,18 @@ export function SketchfabViewer({ onFixAngle }: SketchfabViewerProps) {
             />
             {loading && (
               <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', bgcolor: 'rgba(255,255,255,0.8)', zIndex: 1 }}>
-                <Typography>Loading model...</Typography>
+                <Typography>{t('loadingModel')}</Typography>
               </Box>
             )}
           </Box>
           {/* Buttons below iframe so they're always accessible on iPad */}
           <Box sx={{ display: 'flex', gap: 1, p: 1, borderTop: '1px solid #ddd', bgcolor: '#fafafa' }}>
             <Button variant="outlined" size="small" onClick={handleBack}>
-              Back
+              {t('back')}
             </Button>
             {isReady && (
               <Button variant="contained" color="success" size="small" onClick={handleFixAngle}>
-                Fix This Angle
+                {t('fixThisAngle')}
               </Button>
             )}
           </Box>
@@ -250,14 +251,14 @@ export function SketchfabViewer({ onFixAngle }: SketchfabViewerProps) {
           <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
             <TextField
               size="small"
-              placeholder="Search models..."
+              placeholder={t('searchModels')}
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
               onKeyDown={e => { if (e.key === 'Enter') handleSearch(searchQuery) }}
               sx={{ flex: 1 }}
             />
             <Button size="small" variant="contained" onClick={() => handleSearch(searchQuery)}>
-              Search
+              {t('search')}
             </Button>
           </Box>
 
@@ -265,7 +266,7 @@ export function SketchfabViewer({ onFixAngle }: SketchfabViewerProps) {
           <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mb: 1 }}>
             {SKETCHFAB_CATEGORIES.map(cat => (
               <Button key={cat.slug} size="small" variant="outlined" onClick={() => handleRandomFromCategory(cat.slug)}>
-                {cat.label}
+                {t(cat.labelKey)}
               </Button>
             ))}
           </Box>
@@ -274,17 +275,17 @@ export function SketchfabViewer({ onFixAngle }: SketchfabViewerProps) {
           <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
             <TextField
               size="small"
-              placeholder="Model UID..."
+              placeholder={t('modelUid')}
               value={modelUid}
               onChange={e => setModelUid(e.target.value)}
               sx={{ flex: 1 }}
             />
             <Button size="small" variant="outlined" onClick={() => loadModel(modelUid)} disabled={!modelUid || !scriptLoaded}>
-              Load
+              {t('load')}
             </Button>
           </Box>
 
-          {!scriptLoaded && <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>Loading Sketchfab API...</Typography>}
+          {!scriptLoaded && <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>{t('loadingApi')}</Typography>}
           {error && <Typography variant="body2" color="error" sx={{ mb: 1 }}>{error}</Typography>}
 
           {/* Search results grid */}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,119 @@
+const messages = {
+  en: {
+    // DrawingPanel
+    'pen': 'Pen',
+    'eraser': 'Eraser',
+    'undo': 'Undo',
+    'redo': 'Redo',
+    'clearAll': 'Clear all & reset timer',
+    'compare': 'Compare with reference',
+    'resetZoom': 'Reset zoom',
+    'saveDrawing': 'Save drawing',
+    'gallery': 'Gallery',
+    'delete': 'Delete',
+    'cancel': 'Cancel',
+
+    // ReferencePanel
+    'sketchfab': 'Sketchfab',
+    'image': 'Image',
+    'changeAngle': 'Change Angle',
+    'addGuideLine': 'Add guide line',
+    'deleteGuideLine': 'Delete guide line',
+    'clearGuideLines': 'Clear all guide lines',
+    'toggleGrid': 'Toggle grid',
+    'fullscreen': 'Fullscreen',
+    'exitFullscreen': 'Exit fullscreen',
+    'selectReference': 'Select a reference source above',
+
+    // SketchfabViewer
+    'searchModels': 'Search models...',
+    'search': 'Search',
+    'modelUid': 'Model UID...',
+    'load': 'Load',
+    'loadingModel': 'Loading model...',
+    'loadingApi': 'Loading Sketchfab API...',
+    'back': 'Back',
+    'fixThisAngle': 'Fix This Angle',
+    'failedLoadModel': 'Failed to load model',
+    'failedScreenshot': 'Failed to capture screenshot',
+    'searchFailed': 'Search failed. Try again.',
+    'failedFetchModels': 'Failed to fetch models',
+    'animals': 'Animals',
+    'vehicles': 'Vehicles',
+    'characters': 'Characters',
+    'food': 'Food',
+    'furniture': 'Furniture',
+    'plants': 'Plants',
+    'technology': 'Technology',
+
+    // Gallery
+    'galleryTitle': 'Gallery',
+    'loading': 'Loading...',
+    'noDrawings': 'No saved drawings yet.',
+  },
+  ja: {
+    // DrawingPanel
+    'pen': 'ペン',
+    'eraser': '消しゴム',
+    'undo': '元に戻す',
+    'redo': 'やり直し',
+    'clearAll': '全消去・タイマーリセット',
+    'compare': 'お手本と重ねて比較',
+    'resetZoom': 'ズームリセット',
+    'saveDrawing': '保存',
+    'gallery': 'ギャラリー',
+    'delete': '削除',
+    'cancel': 'キャンセル',
+
+    // ReferencePanel
+    'sketchfab': 'Sketchfab',
+    'image': '画像',
+    'changeAngle': '角度変更',
+    'addGuideLine': '補助線を追加',
+    'deleteGuideLine': '補助線を削除',
+    'clearGuideLines': '補助線を全削除',
+    'toggleGrid': 'グリッド表示切替',
+    'fullscreen': '全画面',
+    'exitFullscreen': '全画面を終了',
+    'selectReference': 'お手本を選んでください',
+
+    // SketchfabViewer
+    'searchModels': 'モデルを検索...',
+    'search': '検索',
+    'modelUid': 'モデルUID...',
+    'load': '読込',
+    'loadingModel': 'モデルを読み込み中...',
+    'loadingApi': 'Sketchfab APIを読み込み中...',
+    'back': '戻る',
+    'fixThisAngle': 'この角度で固定',
+    'failedLoadModel': 'モデルの読み込みに失敗しました',
+    'failedScreenshot': 'スクリーンショットの取得に失敗しました',
+    'searchFailed': '検索に失敗しました。もう一度お試しください。',
+    'failedFetchModels': 'モデルの取得に失敗しました',
+    'animals': '動物',
+    'vehicles': '乗り物',
+    'characters': 'キャラクター',
+    'food': '食べ物',
+    'furniture': '家具',
+    'plants': '植物',
+    'technology': 'テクノロジー',
+
+    // Gallery
+    'galleryTitle': 'ギャラリー',
+    'loading': '読み込み中...',
+    'noDrawings': '保存された絵はまだありません。',
+  },
+} as const
+
+type MessageKey = keyof typeof messages.en
+
+function detectLanguage(): 'ja' | 'en' {
+  const lang = navigator.language
+  return lang.startsWith('ja') ? 'ja' : 'en'
+}
+
+const currentLang = detectLanguage()
+
+export function t(key: MessageKey): string {
+  return messages[currentLang][key] ?? messages.en[key]
+}


### PR DESCRIPTION
## Summary
- `src/i18n.ts` を追加。`navigator.language` でブラウザの言語を検出し、日本語/英語を自動切替
- 全コンポーネントのUI文字列（ツールチップ、ボタン、メッセージ、プレースホルダー）を `t()` 関数経由に変更
- 「角度変更」ボタンの動作を修正: SketchfabViewerをアンマウントせず隠して保持するように変更。角度変更時に同じモデルのビューアに戻る
- ギャラリーの日付フォーマットをブラウザロケールに変更

## Test plan
- [x] ブラウザの言語を日本語にして、全UIが日本語で表示されることを確認
- [ ] 英語環境で英語表示されることを確認
- [x] Sketchfabで角度固定後、「角度変更」ボタンで同じモデルのビューアに戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)