### PR TITLE
fix: move compare button to reference panel

### DIFF
--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from 'react'
+import { useRef, useState, useCallback, useEffect } from 'react'
 import { Box, IconButton, Tooltip, Button, Typography } from '@mui/material'
 import { DrawingCanvas, type DrawingMode } from './DrawingCanvas'
 import { StrokeManager } from '../drawing/StrokeManager'
@@ -8,15 +8,16 @@ import { saveDrawing } from '../storage'
 import { generateThumbnail } from '../storage/generateThumbnail'
 import { Gallery } from './Gallery'
 import { t } from '../i18n'
-import type { Stroke } from '../drawing/types'
 
 interface DrawingPanelProps {
-  onOverlayStrokes?: (strokes: readonly Stroke[] | null) => void
   referenceInfo?: string
   referenceSize?: { width: number; height: number } | null
+  onStrokeManagerReady?: (sm: StrokeManager) => void
+  onStrokesChanged?: () => void
+  onOverlayClear?: () => void
 }
 
-export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSize }: DrawingPanelProps) {
+export function DrawingPanel({ referenceInfo = '', referenceSize, onStrokeManagerReady, onStrokesChanged, onOverlayClear }: DrawingPanelProps) {
   const strokeManagerRef = useRef(new StrokeManager())
   const [mode, setMode] = useState<DrawingMode>('pen')
   const [highlightedStrokeIndex, setHighlightedStrokeIndex] = useState<number | null>(null)
@@ -25,18 +26,16 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
   const [canRedo, setCanRedo] = useState(false)
   const [redrawVersion, setRedrawVersion] = useState(0)
   const [viewResetVersion, setViewResetVersion] = useState(0)
-  const [overlayActive, setOverlayActive] = useState(false)
   const [showGallery, setShowGallery] = useState(false)
   const [saving, setSaving] = useState(false)
 
   const { grid, lines, version: guideVersion } = useGuides()
   const timer = useTimer()
 
-  const syncOverlay = useCallback(() => {
-    if (overlayActive) {
-      onOverlayStrokes?.([...strokeManagerRef.current.getStrokes()])
-    }
-  }, [overlayActive, onOverlayStrokes])
+  // Expose stroke manager to parent
+  useEffect(() => {
+    onStrokeManagerReady?.(strokeManagerRef.current)
+  }, [onStrokeManagerReady])
 
   const syncUndoRedoState = useCallback(() => {
     setCanUndo(strokeManagerRef.current.canUndo())
@@ -46,9 +45,9 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
 
   const triggerRedraw = useCallback(() => {
     syncUndoRedoState()
-    syncOverlay()
+    onStrokesChanged?.()
     setRedrawVersion(v => v + 1)
-  }, [syncUndoRedoState, syncOverlay])
+  }, [syncUndoRedoState, onStrokesChanged])
 
   const handleUndo = useCallback(() => {
     strokeManagerRef.current.undo()
@@ -68,12 +67,8 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
     setMode('pen')
     timer.reset()
     triggerRedraw()
-    // Clear overlay
-    if (overlayActive) {
-      setOverlayActive(false)
-      onOverlayStrokes?.(null)
-    }
-  }, [triggerRedraw, timer, overlayActive, onOverlayStrokes])
+    onOverlayClear?.()
+  }, [triggerRedraw, timer, onOverlayClear])
 
   const handleDeleteHighlighted = useCallback(() => {
     if (highlightedStrokeIndex !== null) {
@@ -89,23 +84,11 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
 
   const handleStrokeCountChange = useCallback(() => {
     syncUndoRedoState()
-    syncOverlay()
-    // Auto-start timer on first stroke
+    onStrokesChanged?.()
     if (!timer.isRunning && strokeManagerRef.current.getStrokes().length > 0) {
       timer.start()
     }
-  }, [syncUndoRedoState, syncOverlay, timer])
-
-  const handleToggleOverlay = useCallback(() => {
-    if (overlayActive) {
-      setOverlayActive(false)
-      onOverlayStrokes?.(null)
-    } else {
-      setOverlayActive(true)
-      const strokes = strokeManagerRef.current.getStrokes()
-      onOverlayStrokes?.(strokes.length > 0 ? [...strokes] : [])
-    }
-  }, [overlayActive, onOverlayStrokes])
+  }, [syncUndoRedoState, onStrokesChanged, timer])
 
   const handleSave = useCallback(async () => {
     const strokes = strokeManagerRef.current.getStrokes()
@@ -128,7 +111,6 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
           py: 0.5,
           borderBottom: '1px solid #ddd',
           bgcolor: '#fafafa',
-          flexWrap: 'wrap',
           minHeight: 40,
         }}
       >
@@ -192,21 +174,7 @@ export function DrawingPanel({ onOverlayStrokes, referenceInfo = '', referenceSi
 
         <Box sx={{ flex: 1 }} />
 
-        {/* View & compare */}
-        <Tooltip title={t('compare')}>
-          <IconButton
-            size="small"
-            onClick={handleToggleOverlay}
-            sx={{
-              bgcolor: overlayActive ? 'warning.main' : 'transparent',
-              color: overlayActive ? 'white' : 'inherit',
-              '&:hover': { bgcolor: overlayActive ? 'warning.dark' : 'action.hover' },
-            }}
-          >
-            &#9881;
-          </IconButton>
-        </Tooltip>
-
+        {/* View */}
         <Tooltip title={t('resetZoom')}>
           <IconButton size="small" onClick={() => setViewResetVersion(v => v + 1)}>
             &#8858;

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -13,9 +13,11 @@ type ReferenceMode = 'browse' | 'fixed'
 interface ReferencePanelProps {
   overlayStrokes?: readonly Stroke[] | null
   onReferenceImageSize?: (width: number, height: number) => void
+  overlayActive?: boolean
+  onToggleOverlay?: () => void
 }
 
-export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: ReferencePanelProps) {
+export function ReferencePanel({ overlayStrokes, onReferenceImageSize, overlayActive, onToggleOverlay }: ReferencePanelProps) {
   const { grid, lines, version: guideVersion, toggleGrid, addLine, removeLine, clearLines } = useGuides()
   const { isFullscreen, toggleFullscreen, isSupported: fullscreenSupported } = useFullscreen()
   const [source, setSource] = useState<ReferenceSource>('none')
@@ -177,6 +179,20 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize }: Referen
         )}
 
         {/* View controls */}
+        <Tooltip title={t('compare')}>
+          <IconButton
+            size="small"
+            onClick={onToggleOverlay}
+            sx={{
+              bgcolor: overlayActive ? 'warning.main' : 'transparent',
+              color: overlayActive ? 'white' : 'inherit',
+              '&:hover': { bgcolor: overlayActive ? 'warning.dark' : 'action.hover' },
+            }}
+          >
+            &#9881;
+          </IconButton>
+        </Tooltip>
+
         <Tooltip title={t('toggleGrid')}>
           <IconButton
             size="small"

--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -1,24 +1,53 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef, useEffect } from 'react'
 import { Box } from '@mui/material'
 import { useOrientation } from '../hooks/useOrientation'
 import { GuideProvider } from '../guides/GuideContext'
 import { ReferencePanel } from './ReferencePanel'
 import { DrawingPanel } from './DrawingPanel'
+import { StrokeManager } from '../drawing/StrokeManager'
 import type { Stroke } from '../drawing/types'
 
 export function SplitLayout() {
   const orientation = useOrientation()
   const isLandscape = orientation === 'landscape'
   const [overlayStrokes, setOverlayStrokes] = useState<readonly Stroke[] | null>(null)
+  const [overlayActive, setOverlayActive] = useState(false)
   const [referenceSize, setReferenceSize] = useState<{ width: number; height: number } | null>(null)
-
-  const handleOverlayStrokes = useCallback((strokes: readonly Stroke[] | null) => {
-    setOverlayStrokes(strokes)
-  }, [])
+  const strokeManagerRef = useRef<StrokeManager | null>(null)
 
   const handleReferenceImageSize = useCallback((width: number, height: number) => {
     setReferenceSize({ width, height })
   }, [])
+
+  const handleToggleOverlay = useCallback(() => {
+    setOverlayActive(prev => {
+      const next = !prev
+      if (next && strokeManagerRef.current) {
+        setOverlayStrokes([...strokeManagerRef.current.getStrokes()])
+      } else {
+        setOverlayStrokes(null)
+      }
+      return next
+    })
+  }, [])
+
+  const handleStrokeManagerReady = useCallback((sm: StrokeManager) => {
+    strokeManagerRef.current = sm
+  }, [])
+
+  // Sync overlay when strokes change (called by DrawingPanel)
+  const handleStrokesChanged = useCallback(() => {
+    if (overlayActive && strokeManagerRef.current) {
+      setOverlayStrokes([...strokeManagerRef.current.getStrokes()])
+    }
+  }, [overlayActive])
+
+  // Clear overlay when drawing is cleared
+  useEffect(() => {
+    if (overlayActive && overlayStrokes && overlayStrokes.length === 0) {
+      // Keep overlay active even with no strokes (live mode)
+    }
+  }, [overlayActive, overlayStrokes])
 
   return (
     <GuideProvider>
@@ -32,10 +61,20 @@ export function SplitLayout() {
         }}
       >
         <Box sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
-          <ReferencePanel overlayStrokes={overlayStrokes} onReferenceImageSize={handleReferenceImageSize} />
+          <ReferencePanel
+            overlayStrokes={overlayStrokes}
+            onReferenceImageSize={handleReferenceImageSize}
+            overlayActive={overlayActive}
+            onToggleOverlay={handleToggleOverlay}
+          />
         </Box>
         <Box sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
-          <DrawingPanel onOverlayStrokes={handleOverlayStrokes} referenceSize={referenceSize} />
+          <DrawingPanel
+            referenceSize={referenceSize}
+            onStrokeManagerReady={handleStrokeManagerReady}
+            onStrokesChanged={handleStrokesChanged}
+            onOverlayClear={() => { setOverlayActive(false); setOverlayStrokes(null) }}
+          />
         </Box>
       </Box>
     </GuideProvider>


### PR DESCRIPTION
## Summary
- 答え合わせ(⚙)ボタンをドロー画面からお手本画面のツールバーに移動
- ドロー画面のツールバーが狭い画面で2行に折り返す問題を解消
- 状態管理をSplitLayoutに引き上げ: DrawingPanelがStrokeManagerをコールバックで公開し、SplitLayoutがオーバーレイストロークを同期

## Test plan
- [x] お手本画面の⚙ボタンで答え合わせが機能することを確認
- [x] ドロー画面のツールバーが1行に収まることを確認
- [x] 答え合わせモード中のストロークリアルタイム同期が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)