### PR TITLE
feat: show reference title and author overlay on fixed image

### DIFF
--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef } from 'react'
-import { Box, Button, Tooltip, IconButton } from '@mui/material'
-import { SketchfabViewer, type SketchfabActions } from './SketchfabViewer'
+import { Box, Button, Tooltip, IconButton, Typography } from '@mui/material'
+import { SketchfabViewer, type SketchfabActions, type ReferenceInfo } from './SketchfabViewer'
 import { ImageViewer, type GuideInteractionMode } from './ImageViewer'
 import { useGuides } from '../guides/useGuides'
 import { useFullscreen } from '../hooks/useFullscreen'
@@ -26,6 +26,7 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize, overlayAc
   const [localImageUrl, setLocalImageUrl] = useState<string | null>(null)
   const [viewResetVersion, setViewResetVersion] = useState(0)
   const [guideMode, setGuideMode] = useState<GuideInteractionMode>('none')
+  const [refInfo, setRefInfo] = useState<ReferenceInfo | null>(null)
   const [highlightedGuideId, setHighlightedGuideId] = useState<string | null>(null)
 
   // Sketchfab viewer state (reported by child)
@@ -42,14 +43,16 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize, overlayAc
       if (!file) return
       const url = URL.createObjectURL(file)
       setLocalImageUrl(url)
+      setRefInfo({ title: file.name, author: '', source: 'image', fileName: file.name })
       setSource('image')
       setReferenceMode('fixed')
     }
     input.click()
   }, [])
 
-  const handleFixAngle = useCallback((screenshotUrl: string) => {
+  const handleFixAngle = useCallback((screenshotUrl: string, info: ReferenceInfo) => {
     setFixedImageUrl(screenshotUrl)
+    setRefInfo(info)
     setReferenceMode('fixed')
   }, [])
 
@@ -63,6 +66,7 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize, overlayAc
     setReferenceMode('browse')
     setFixedImageUrl(null)
     setLocalImageUrl(null)
+    setRefInfo(null)
     setGuideMode('none')
     setHighlightedGuideId(null)
   }, [])
@@ -280,6 +284,34 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize, overlayAc
               onStateChange={handleSfStateChange}
               actionsRef={sfActionsRef}
             />
+          </Box>
+        )}
+
+        {/* Reference info overlay */}
+        {isFixed && refInfo && (refInfo.title || refInfo.author) && (
+          <Box sx={{
+            position: 'absolute',
+            bottom: 8,
+            left: 8,
+            zIndex: 5,
+            bgcolor: 'rgba(0,0,0,0.5)',
+            color: 'white',
+            px: 1,
+            py: 0.5,
+            borderRadius: 1,
+            maxWidth: '80%',
+            pointerEvents: 'none',
+          }}>
+            {refInfo.title && (
+              <Typography variant="caption" sx={{ display: 'block', fontWeight: 'bold', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {refInfo.title}
+              </Typography>
+            )}
+            {refInfo.author && (
+              <Typography variant="caption" sx={{ display: 'block', opacity: 0.8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {refInfo.author}
+              </Typography>
+            )}
           </Box>
         )}
 

--- a/src/components/SketchfabViewer.tsx
+++ b/src/components/SketchfabViewer.tsx
@@ -2,8 +2,15 @@ import { useState, useCallback, useRef, useEffect } from 'react'
 import { Box, Button, TextField, Typography } from '@mui/material'
 import { t } from '../i18n'
 
+export interface ReferenceInfo {
+  title: string
+  author: string
+  source: 'sketchfab' | 'image'
+  fileName?: string
+}
+
 interface SketchfabViewerProps {
-  onFixAngle: (screenshotUrl: string) => void
+  onFixAngle: (screenshotUrl: string, info: ReferenceInfo) => void
   /** Called when viewer state changes so parent can update toolbar */
   onStateChange?: (state: { showViewer: boolean; isReady: boolean }) => void
   /** Ref for imperative actions from parent */
@@ -45,6 +52,7 @@ declare global {
 interface SearchResult {
   uid: string
   name: string
+  author: string
   thumbnailUrl: string
 }
 
@@ -66,6 +74,7 @@ interface ThumbnailImage {
 interface ModelResult {
   uid: string
   name: string
+  user?: { displayName?: string; username?: string }
   thumbnails?: { images?: ThumbnailImage[] }
 }
 
@@ -73,6 +82,7 @@ function parseSearchResults(data: { results?: ModelResult[] }): SearchResult[] {
   return data.results?.map(m => ({
     uid: m.uid,
     name: m.name,
+    author: m.user?.displayName ?? m.user?.username ?? '',
     thumbnailUrl: m.thumbnails?.images?.find(t => t.width >= 200)?.url ?? '',
   })) ?? []
 }
@@ -88,6 +98,7 @@ export function SketchfabViewer({ onFixAngle, onStateChange, actionsRef }: Sketc
   const [scriptLoaded, setScriptLoaded] = useState(!!window.Sketchfab)
   const [searchQuery, setSearchQuery] = useState('')
   const [searchResults, setSearchResults] = useState<SearchResult[]>([])
+  const [selectedModel, setSelectedModel] = useState<{ name: string; author: string } | null>(null)
   // Pending model UID to load once iframe is mounted
   const pendingLoadRef = useRef<string | null>(null)
 
@@ -168,9 +179,13 @@ export function SketchfabViewer({ onFixAngle, onStateChange, actionsRef }: Sketc
         setError(t('failedScreenshot'))
         return
       }
-      onFixAngle(result)
+      onFixAngle(result, {
+        title: selectedModel?.name ?? '',
+        author: selectedModel?.author ?? '',
+        source: 'sketchfab',
+      })
     })
-  }, [onFixAngle])
+  }, [onFixAngle, selectedModel])
 
   const handleSearch = useCallback(async (query: string, category?: string) => {
     setError(null)
@@ -210,9 +225,10 @@ export function SketchfabViewer({ onFixAngle, onStateChange, actionsRef }: Sketc
       .catch(() => setError(t('failedFetchModels')))
   }, [])
 
-  const handleSelectModel = useCallback((uid: string) => {
-    setModelUid(uid)
-    loadModel(uid)
+  const handleSelectModel = useCallback((model: SearchResult) => {
+    setModelUid(model.uid)
+    setSelectedModel({ name: model.name, author: model.author })
+    loadModel(model.uid)
   }, [loadModel])
 
   const handleBack = useCallback(() => {
@@ -305,7 +321,7 @@ export function SketchfabViewer({ onFixAngle, onStateChange, actionsRef }: Sketc
               {searchResults.map(model => (
                 <Box
                   key={model.uid}
-                  onClick={() => handleSelectModel(model.uid)}
+                  onClick={() => handleSelectModel(model)}
                   sx={{
                     cursor: 'pointer',
                     border: '1px solid #ddd',


### PR DESCRIPTION
## Summary
- お手本画像固定時に、左下に半透明でタイトルと作者名をオーバーレイ表示
  - Sketchfab: モデル名 + 作者名（Data APIの`user.displayName`から取得）
  - ローカル画像: ファイル名
- `ReferenceInfo`型を追加し、`onFixAngle`コールバックで情報を伝達
- 検索結果に`author`フィールドを追加

## Test plan
- [x] Sketchfabモデルを固定後、左下にモデル名と作者名が表示されることを確認
- [x] ローカル画像を読み込み後、左下にファイル名が表示されることを確認
- [x] ×ボタンで閉じると情報もクリアされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)