### PR TITLE
feat: show build timestamp on initial screen

### DIFF
--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -286,17 +286,23 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize, overlayAc
         {isNone && (
           <Box sx={{
             display: 'flex',
+            flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
             height: '100%',
             gap: 2,
           }}>
-            <Button variant="outlined" size="large" onClick={handleOpenSketchfab}>
-              {t('sketchfab')}
-            </Button>
-            <Button variant="outlined" size="large" onClick={handleLoadLocalImage}>
-              {t('image')}
-            </Button>
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Button variant="outlined" size="large" onClick={handleOpenSketchfab}>
+                {t('sketchfab')}
+              </Button>
+              <Button variant="outlined" size="large" onClick={handleLoadLocalImage}>
+                {t('image')}
+              </Button>
+            </Box>
+            <Typography variant="caption" color="text.disabled">
+              {t('buildDate')}: {new Date(import.meta.env.BUILD_DATE as string).toLocaleString()}
+            </Typography>
           </Box>
         )}
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -51,6 +51,7 @@ const messages = {
     'loading': 'Loading...',
     'noDrawings': 'No saved drawings yet.',
     'loadReference': 'Use this reference',
+    'buildDate': 'Build',
   },
   ja: {
     // DrawingPanel
@@ -104,6 +105,7 @@ const messages = {
     'loading': '読み込み中...',
     'noDrawings': '保存された絵はまだありません。',
     'loadReference': 'このお手本で練習',
+    'buildDate': 'ビルド',
   },
 } as const
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    'import.meta.env.BUILD_DATE': JSON.stringify(new Date().toISOString()),
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- vite.configでビルド時にUTC ISO文字列を`import.meta.env.BUILD_DATE`に注入
- お手本未選択画面のSketchfab/Imageボタンの下に「ビルド: 日時」を表示
- `toLocaleString()`でユーザーのローカルタイムゾーンに変換して表示
- i18nでラベル対応（Build / ビルド）

## Test plan
- [ ] お手本未選択画面にビルド日時が表示されることを確認
- [ ] 日本語/英語環境でラベルが切り替わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)