### PR TITLE
feat: auto-select latest guide line in delete mode

### DIFF
--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -178,18 +178,28 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize, overlayAc
   const handleDeleteHighlighted = useCallback(() => {
     if (highlightedGuideId) {
       removeLine(highlightedGuideId)
-      setHighlightedGuideId(null)
+      // 削除後、残りの末尾を自動選択（連続削除を容易にする）
+      const remaining = lines.filter(l => l.id !== highlightedGuideId)
+      setHighlightedGuideId(remaining.length > 0 ? remaining[remaining.length - 1].id : null)
     }
-  }, [highlightedGuideId, removeLine])
+  }, [highlightedGuideId, removeLine, lines])
 
   const handleCancelHighlight = useCallback(() => {
     setHighlightedGuideId(null)
   }, [])
 
   const toggleGuideMode = useCallback((mode: GuideInteractionMode) => {
-    setGuideMode(prev => prev === mode ? 'none' : mode)
-    setHighlightedGuideId(null)
-  }, [])
+    setGuideMode(prev => {
+      const nextMode = prev === mode ? 'none' : mode
+      // deleteモードに入る時、最新の補助線を自動選択
+      if (nextMode === 'delete' && lines.length > 0) {
+        setHighlightedGuideId(lines[lines.length - 1].id)
+      } else {
+        setHighlightedGuideId(null)
+      }
+      return nextMode
+    })
+  }, [lines])
 
   const displayImageUrl = source === 'image' ? localImageUrl : fixedImageUrl  // 'sketchfab' and 'url' use fixedImageUrl
   const isFixed = referenceMode === 'fixed' && !!displayImageUrl

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -178,9 +178,10 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize, overlayAc
   const handleDeleteHighlighted = useCallback(() => {
     if (highlightedGuideId) {
       removeLine(highlightedGuideId)
-      // 削除後、残りの末尾を自動選択（連続削除を容易にする）
-      const remaining = lines.filter(l => l.id !== highlightedGuideId)
-      setHighlightedGuideId(remaining.length > 0 ? remaining[remaining.length - 1].id : null)
+      // 削除後、削除した線の一つ前を自動選択
+      const idx = lines.findIndex(l => l.id === highlightedGuideId)
+      const prevIdx = idx - 1
+      setHighlightedGuideId(prevIdx >= 0 ? lines[prevIdx].id : null)
     }
   }, [highlightedGuideId, removeLine, lines])
 


### PR DESCRIPTION
## Summary
- 補助線の削除モードに入る際、最新の補助線を自動的にハイライト選択するようにした
- 補助線を削除した後、削除した線の一つ前の補助線を自動選択するようにした（タップで選択した場合、末尾を意図的に避けた可能性があるため）
- 削除モードをオフにした場合やaddモードではハイライトを適切にクリア

## Test plan
- [x] リファレンス画像を固定し、補助線を複数本追加
- [x] 削除ボタンを押す → 最後に追加した線がハイライトされていること
- [x] 「Delete」で削除 → 次の末尾の線が自動選択されること
- [x] 連続でDeleteを押して末尾から順に消せること
- [x] 全て消えたらハイライトがクリアされること
- [x] 削除モード中に別の線をタップして選択し直せること
- [x] 追加モード・全消去ボタンが正常に動作すること
- [x] 削除後、削除した線の一つ前が選択されること（末尾ではなく）
- [x] 先頭の線を削除した場合、選択がクリアされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)