### PR TITLE
feat: add back button to return to Sketchfab search results

### DIFF
--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -232,6 +232,13 @@ export function ReferencePanel({ overlayStrokes, onReferenceImageSize, overlayAc
           </Tooltip>
         )}
 
+        {/* Sketchfab model viewer: Back to search results */}
+        {isSfBrowse && sfShowViewer && (
+          <Button size="small" variant="outlined" onClick={() => sfActionsRef.current?.back()}>
+            {t('back')}
+          </Button>
+        )}
+
         {/* Sketchfab model viewer: Fix This Angle button */}
         {isSfBrowse && sfShowViewer && sfIsReady && (
           <Button size="small" variant="contained" color="success" onClick={() => sfActionsRef.current?.fixAngle()}>


### PR DESCRIPTION
## Summary
- Sketchfab 3Dモデルプレビュー中のツールバーに「戻る」ボタンを追加
- 検索結果を保持したまま一覧に戻れるようになり、複数モデルの比較が容易に
- 既存のXボタン（完全終了）との使い分けが明確に

## Test plan
- [x] Sketchfabで検索→モデル選択→「戻る」ボタンで検索結果に戻ることを確認
- [x] 戻った後に別のモデルを選択できることを確認
- [x] Xボタンは従来通り完全にSketchfabを閉じることを確認
- [x] `npm run lint` / `npm run build` パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)