### PR TITLE
fix: prevent false "another tab" warning during HMR

### DIFF
--- a/src/hooks/useSessionLock.ts
+++ b/src/hooks/useSessionLock.ts
@@ -9,6 +9,13 @@ const supportsLocks = typeof navigator !== 'undefined' && typeof navigator.locks
  * runs autosave at a time. Returns whether this tab holds the lock.
  * Falls back to true (unlocked) in browsers without Web Locks support.
  */
+// Max retries and delay for acquiring the lock.
+// During HMR the old component's lock is released asynchronously, so a
+// short retry window avoids a false "another tab" warning while still
+// detecting genuinely separate tabs quickly.
+const RETRY_DELAY_MS = 100
+const MAX_RETRIES = 3
+
 export function useSessionLock(): boolean {
   const [hasLock, setHasLock] = useState(!supportsLocks)
   const releaseRef = useRef<(() => void) | null>(null)
@@ -18,18 +25,29 @@ export function useSessionLock(): boolean {
 
     let unmounted = false
 
-    navigator.locks.request(LOCK_NAME, { ifAvailable: true }, (lock) => {
-      if (!lock || unmounted) {
-        if (!unmounted) setHasLock(false)
-        return Promise.resolve()
-      }
+    function tryAcquire(retriesLeft: number) {
+      navigator.locks.request(LOCK_NAME, { ifAvailable: true }, (lock) => {
+        if (unmounted) {
+          return Promise.resolve()
+        }
+        if (!lock) {
+          if (retriesLeft > 0) {
+            setTimeout(() => tryAcquire(retriesLeft - 1), RETRY_DELAY_MS)
+          } else {
+            setHasLock(false)
+          }
+          return Promise.resolve()
+        }
 
-      setHasLock(true)
-      // Hold the lock until unmount by returning a pending promise
-      return new Promise<void>((resolve) => {
-        releaseRef.current = resolve
+        setHasLock(true)
+        // Hold the lock until unmount by returning a pending promise
+        return new Promise<void>((resolve) => {
+          releaseRef.current = resolve
+        })
       })
-    })
+    }
+
+    tryAcquire(MAX_RETRIES)
 
     return () => {
       unmounted = true


### PR DESCRIPTION
## Summary
- `npm run dev` でHMRリロードが発生すると、旧コンポーネントのWeb Lockが非同期で解放される前に新コンポーネントがロック取得を試みて失敗し、「別のタブが開いているため、オートセーブが無効です」という誤った警告が表示されていた
- `ifAvailable: true` でのロック取得に失敗した場合、100ms間隔で最大3回リトライするように変更
- HMRの場合は旧ロック解放後すぐに取得成功し、本当に別タブが開いている場合は~300ms後に正しく警告表示

Closes #29

## Test plan
- [x] `npm run lint` パス
- [x] `npm run build` パス
- [x] `npm run test` パス (62 tests)
- [x] `npm run dev` でページを開き、ソースを編集してHMRを発動させても警告が出ないことを確認
- [x] 2つのタブで同時に開いた場合、後から開いたタブに警告が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)