### PR TITLE
chore: enable no-explicit-any eslint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,5 +19,8 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    },
   },
 ])

--- a/src/guides/GuideManager.test.ts
+++ b/src/guides/GuideManager.test.ts
@@ -1,4 +1,5 @@
 import { GuideManager } from './GuideManager'
+import type { GuideLine, GuideState } from './types'
 
 describe('GuideManager', () => {
   let manager: GuideManager
@@ -75,26 +76,24 @@ describe('GuideManager', () => {
     })
 
     it('migrates legacy enabled/spacing format', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const legacyState: any = {
+      const legacyState = {
         grid: { enabled: true, spacing: 50 },
         lines: [{ id: 'guide-100', x1: 0, y1: 0, x2: 100, y2: 100 }],
       }
 
-      manager.importState(legacyState)
+      manager.importState(legacyState as unknown as GuideState)
 
       expect(manager.getGrid().mode).toBe('normal')
       expect(manager.getLines()).toHaveLength(1)
     })
 
     it('migrates legacy disabled format', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const legacyState: any = {
+      const legacyState = {
         grid: { enabled: false, spacing: 100 },
-        lines: [],
+        lines: [] as GuideLine[],
       }
 
-      manager.importState(legacyState)
+      manager.importState(legacyState as unknown as GuideState)
 
       expect(manager.getGrid().mode).toBe('none')
     })

--- a/src/guides/GuideManager.test.ts
+++ b/src/guides/GuideManager.test.ts
@@ -1,6 +1,12 @@
 import { GuideManager } from './GuideManager'
 import type { GuideLine, GuideState } from './types'
 
+/** Simulates the legacy persisted format before GridMode migration */
+interface LegacyGuideState {
+  grid: { enabled: boolean; spacing: number }
+  lines: GuideLine[]
+}
+
 describe('GuideManager', () => {
   let manager: GuideManager
 
@@ -76,7 +82,7 @@ describe('GuideManager', () => {
     })
 
     it('migrates legacy enabled/spacing format', () => {
-      const legacyState = {
+      const legacyState: LegacyGuideState = {
         grid: { enabled: true, spacing: 50 },
         lines: [{ id: 'guide-100', x1: 0, y1: 0, x2: 100, y2: 100 }],
       }
@@ -88,9 +94,9 @@ describe('GuideManager', () => {
     })
 
     it('migrates legacy disabled format', () => {
-      const legacyState = {
+      const legacyState: LegacyGuideState = {
         grid: { enabled: false, spacing: 100 },
-        lines: [] as GuideLine[],
+        lines: [],
       }
 
       manager.importState(legacyState as unknown as GuideState)

--- a/src/guides/types.ts
+++ b/src/guides/types.ts
@@ -41,15 +41,26 @@ export function nextGridMode(current: GridMode): GridMode {
   return GRID_MODE_CYCLE[(idx + 1) % GRID_MODE_CYCLE.length]
 }
 
+/** Legacy grid settings stored before the GridMode migration */
+interface LegacyGridSettings {
+  enabled: boolean
+  spacing: number
+}
+
+function isGridSettings(grid: object): grid is GridSettings {
+  return 'mode' in grid && typeof (grid as GridSettings).mode === 'string'
+}
+
+function isLegacyGridSettings(grid: object): grid is LegacyGridSettings {
+  return 'enabled' in grid && typeof (grid as LegacyGridSettings).enabled === 'boolean'
+}
+
 /** Migrate legacy { enabled, spacing } format to { mode } */
 export function migrateGridSettings(grid: unknown): GridSettings {
   if (grid && typeof grid === 'object') {
-    if ('mode' in grid && typeof (grid as GridSettings).mode === 'string') {
-      return grid as GridSettings
-    }
-    // Legacy format: { enabled: boolean, spacing: number }
-    if ('enabled' in grid && typeof (grid as Record<string, unknown>).enabled === 'boolean') {
-      return { mode: (grid as Record<string, unknown>).enabled ? 'normal' : 'none' }
+    if (isGridSettings(grid)) return grid
+    if (isLegacyGridSettings(grid)) {
+      return { mode: grid.enabled ? 'normal' : 'none' }
     }
   }
   return DEFAULT_GUIDE_STATE.grid

--- a/src/guides/types.ts
+++ b/src/guides/types.ts
@@ -42,12 +42,15 @@ export function nextGridMode(current: GridMode): GridMode {
 }
 
 /** Migrate legacy { enabled, spacing } format to { mode } */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function migrateGridSettings(grid: any): GridSettings {
-  if (grid && typeof grid.mode === 'string') return grid as GridSettings
-  // Legacy format: { enabled: boolean, spacing: number }
-  if (grid && typeof grid.enabled === 'boolean') {
-    return { mode: grid.enabled ? 'normal' : 'none' }
+export function migrateGridSettings(grid: unknown): GridSettings {
+  if (grid && typeof grid === 'object') {
+    if ('mode' in grid && typeof (grid as GridSettings).mode === 'string') {
+      return grid as GridSettings
+    }
+    // Legacy format: { enabled: boolean, spacing: number }
+    if ('enabled' in grid && typeof (grid as Record<string, unknown>).enabled === 'boolean') {
+      return { mode: (grid as Record<string, unknown>).enabled ? 'normal' : 'none' }
+    }
   }
   return DEFAULT_GUIDE_STATE.grid
 }


### PR DESCRIPTION
## Summary
- `@typescript-eslint/no-explicit-any` を `error` として有効化
- 既存の `any` 使用箇所（3箇所）を全て修正:
  - `migrateGridSettings` の引数を `any` → `unknown` に変更
  - `isGridSettings()` / `isLegacyGridSettings()` 型ガード関数を導入し、キャストを排除
  - `LegacyGridSettings` / `LegacyGuideState` 型を定義してレガシーデータ構造を明示化
  - テストの eslint-disable コメントを削除

Closes #32

## Test plan
- [x] `npm run lint` パス（新ルールで `any` が検出されないことを確認）
- [x] `npm run build` パス
- [x] `npm run test` パス (62 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)