### PR TITLE
fix: re-fit drawing canvas on resize to match reference panel

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -141,8 +141,13 @@ export function DrawingCanvas({
     ctx.scale(dpr, dpr)
 
     rendererRef.current = new CanvasRenderer(ctx)
+
+    // Re-fit to reference size on resize (matches ImageViewer behavior)
+    if (fitSize) {
+      fitToSize()
+    }
     redrawAll()
-  }, [redrawAll])
+  }, [redrawAll, fitSize, fitToSize])
 
   // ResizeObserver
   useEffect(() => {


### PR DESCRIPTION
## Summary
- 画面の縦横切替やウィンドウリサイズ時に、描画キャンバスの表示位置がずれるバグを修正
- `setupCanvas` 内でリサイズ時に `fitToSize()` を呼び出し、お手本パネル（ImageViewer）と同じfit動作に統一

Closes #46

## Test plan
- [ ] iPadで縦横回転し、描画キャンバスの表示が中央に正しくfit し直されることを確認
- [x] PCでウィンドウリサイズ時に描画キャンバスが正しくfitすることを確認
- [x] お手本パネルと描画パネルのグリッドが揃っていることを確認
- [ ] リサイズ後も描画操作（ペン、消しゴム、ズーム/パン）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)