### PR TITLE
fix: allow tap-again to delete highlighted stroke in eraser mode

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -13,6 +13,7 @@ interface DrawingCanvasProps {
   mode: DrawingMode
   highlightedStrokeIndex: number | null
   onHighlightStroke: (index: number | null) => void
+  onDeleteHighlightedStroke?: () => void
   onStrokeCountChange: () => void
   strokeManagerRef: React.RefObject<StrokeManager>
   /** Increment this to force a canvas redraw (e.g. after undo/redo/clear). */
@@ -34,6 +35,7 @@ export function DrawingCanvas({
   mode,
   highlightedStrokeIndex,
   onHighlightStroke,
+  onDeleteHighlightedStroke,
   onStrokeCountChange,
   strokeManagerRef,
   redrawVersion,
@@ -281,12 +283,16 @@ export function DrawingCanvas({
 
     if (mode === 'eraser') {
       const index = strokeManagerRef.current.findNearestStroke(point, ERASER_THRESHOLD / viewTransformRef.current.get().scale)
-      onHighlightStroke(index)
+      if (index !== null && index === highlightedStrokeIndex) {
+        onDeleteHighlightedStroke?.()
+      } else {
+        onHighlightStroke(index)
+      }
     } else {
       strokeManagerRef.current.startStroke(point)
       drawingPointCountRef.current = 1
     }
-  }, [mode, getCanvasPoint, onHighlightStroke, strokeManagerRef])
+  }, [mode, getCanvasPoint, onHighlightStroke, onDeleteHighlightedStroke, highlightedStrokeIndex, strokeManagerRef])
 
   const handleTouchMove = useCallback((e: React.TouchEvent) => {
     e.preventDefault()
@@ -378,12 +384,16 @@ export function DrawingCanvas({
 
     if (mode === 'eraser') {
       const index = strokeManagerRef.current.findNearestStroke(point, ERASER_THRESHOLD / viewTransformRef.current.get().scale)
-      onHighlightStroke(index)
+      if (index !== null && index === highlightedStrokeIndex) {
+        onDeleteHighlightedStroke?.()
+      } else {
+        onHighlightStroke(index)
+      }
     } else {
       strokeManagerRef.current.startStroke(point)
       drawingPointCountRef.current = 1
     }
-  }, [mode, getCanvasPoint, onHighlightStroke, strokeManagerRef])
+  }, [mode, getCanvasPoint, onHighlightStroke, onDeleteHighlightedStroke, highlightedStrokeIndex, strokeManagerRef])
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
     if (!isMouseDownRef.current || mode !== 'pen') return

--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -258,6 +258,7 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
           mode={mode}
           highlightedStrokeIndex={highlightedStrokeIndex}
           onHighlightStroke={setHighlightedStrokeIndex}
+          onDeleteHighlightedStroke={handleDeleteHighlighted}
           onStrokeCountChange={handleStrokeCountChange}
           strokeManagerRef={strokeManagerRef}
           redrawVersion={redrawVersion}

--- a/src/drawing/StrokeManager.test.ts
+++ b/src/drawing/StrokeManager.test.ts
@@ -170,6 +170,91 @@ describe('StrokeManager', () => {
       expect(manager.getStrokes()[1].points[0]).toEqual({ x: 20, y: 20 })
     })
 
+    it('can undo multiple consecutive deletes', () => {
+      manager.startStroke({ x: 0, y: 0 })
+      manager.appendStroke({ x: 10, y: 10 })
+      manager.endStroke()
+
+      manager.startStroke({ x: 20, y: 20 })
+      manager.appendStroke({ x: 30, y: 30 })
+      manager.endStroke()
+
+      manager.startStroke({ x: 40, y: 40 })
+      manager.appendStroke({ x: 50, y: 50 })
+      manager.endStroke()
+
+      // Delete first, then second (now at index 0)
+      manager.deleteStroke(0)
+      manager.deleteStroke(0)
+      expect(manager.getStrokes()).toHaveLength(1)
+      expect(manager.getStrokes()[0].points[0]).toEqual({ x: 40, y: 40 })
+
+      // Undo both deletes
+      manager.undo()
+      expect(manager.getStrokes()).toHaveLength(2)
+      expect(manager.getStrokes()[0].points[0]).toEqual({ x: 20, y: 20 })
+
+      manager.undo()
+      expect(manager.getStrokes()).toHaveLength(3)
+      expect(manager.getStrokes()[0].points[0]).toEqual({ x: 0, y: 0 })
+    })
+
+    it('undo interleaves add and delete in chronological order', () => {
+      // Draw 3 strokes
+      manager.startStroke({ x: 0, y: 0 })
+      manager.appendStroke({ x: 10, y: 10 })
+      manager.endStroke()
+
+      manager.startStroke({ x: 20, y: 20 })
+      manager.appendStroke({ x: 30, y: 30 })
+      manager.endStroke()
+
+      manager.startStroke({ x: 40, y: 40 })
+      manager.appendStroke({ x: 50, y: 50 })
+      manager.endStroke()
+
+      // Delete middle stroke, then draw another
+      manager.deleteStroke(1)
+      expect(manager.getStrokes()).toHaveLength(2)
+
+      manager.startStroke({ x: 60, y: 60 })
+      manager.appendStroke({ x: 70, y: 70 })
+      manager.endStroke()
+      expect(manager.getStrokes()).toHaveLength(3)
+
+      // Undo should reverse: remove last added, then restore deleted
+      manager.undo() // undo add of (60,60)
+      expect(manager.getStrokes()).toHaveLength(2)
+      expect(manager.getStrokes()[1].points[0]).toEqual({ x: 40, y: 40 })
+
+      manager.undo() // undo delete of (20,20)
+      expect(manager.getStrokes()).toHaveLength(3)
+      expect(manager.getStrokes()[1].points[0]).toEqual({ x: 20, y: 20 })
+
+      manager.undo() // undo add of (40,40)
+      expect(manager.getStrokes()).toHaveLength(2)
+    })
+
+    it('redo replays delete after undo', () => {
+      manager.startStroke({ x: 0, y: 0 })
+      manager.appendStroke({ x: 10, y: 10 })
+      manager.endStroke()
+
+      manager.startStroke({ x: 20, y: 20 })
+      manager.appendStroke({ x: 30, y: 30 })
+      manager.endStroke()
+
+      manager.deleteStroke(0)
+      expect(manager.getStrokes()).toHaveLength(1)
+
+      manager.undo() // restore deleted stroke
+      expect(manager.getStrokes()).toHaveLength(2)
+
+      manager.redo() // re-delete
+      expect(manager.getStrokes()).toHaveLength(1)
+      expect(manager.getStrokes()[0].points[0]).toEqual({ x: 20, y: 20 })
+    })
+
     it('new stroke clears delete undo', () => {
       manager.startStroke({ x: 0, y: 0 })
       manager.appendStroke({ x: 10, y: 10 })

--- a/src/drawing/StrokeManager.test.ts
+++ b/src/drawing/StrokeManager.test.ts
@@ -128,6 +128,67 @@ describe('StrokeManager', () => {
       manager.deleteStroke(0)
       expect(manager.canRedo()).toBe(false)
     })
+
+    it('can undo a delete operation', () => {
+      manager.startStroke({ x: 0, y: 0 })
+      manager.appendStroke({ x: 10, y: 10 })
+      manager.endStroke()
+
+      manager.startStroke({ x: 20, y: 20 })
+      manager.appendStroke({ x: 30, y: 30 })
+      manager.endStroke()
+
+      manager.deleteStroke(0)
+      expect(manager.getStrokes()).toHaveLength(1)
+      expect(manager.canUndo()).toBe(true)
+
+      manager.undo()
+      expect(manager.getStrokes()).toHaveLength(2)
+      expect(manager.getStrokes()[0].points[0]).toEqual({ x: 0, y: 0 })
+      expect(manager.getStrokes()[1].points[0]).toEqual({ x: 20, y: 20 })
+    })
+
+    it('undo after delete restores stroke at original index', () => {
+      manager.startStroke({ x: 0, y: 0 })
+      manager.appendStroke({ x: 10, y: 10 })
+      manager.endStroke()
+
+      manager.startStroke({ x: 20, y: 20 })
+      manager.appendStroke({ x: 30, y: 30 })
+      manager.endStroke()
+
+      manager.startStroke({ x: 40, y: 40 })
+      manager.appendStroke({ x: 50, y: 50 })
+      manager.endStroke()
+
+      // Delete middle stroke
+      manager.deleteStroke(1)
+      expect(manager.getStrokes()).toHaveLength(2)
+
+      manager.undo()
+      expect(manager.getStrokes()).toHaveLength(3)
+      expect(manager.getStrokes()[1].points[0]).toEqual({ x: 20, y: 20 })
+    })
+
+    it('new stroke clears delete undo', () => {
+      manager.startStroke({ x: 0, y: 0 })
+      manager.appendStroke({ x: 10, y: 10 })
+      manager.endStroke()
+
+      manager.deleteStroke(0)
+      expect(manager.getStrokes()).toHaveLength(0)
+      expect(manager.canUndo()).toBe(true)
+
+      // Draw a new stroke — delete undo is lost
+      manager.startStroke({ x: 50, y: 50 })
+      manager.appendStroke({ x: 60, y: 60 })
+      manager.endStroke()
+
+      expect(manager.getStrokes()).toHaveLength(1)
+      // Undo now undoes the new stroke, not the delete
+      manager.undo()
+      expect(manager.getStrokes()).toHaveLength(0)
+    })
   })
 
   describe('findNearestStroke', () => {

--- a/src/drawing/StrokeManager.ts
+++ b/src/drawing/StrokeManager.ts
@@ -1,15 +1,20 @@
 import type { Point, Stroke } from './types'
 
-interface DeleteRecord {
-  stroke: Stroke
-  index: number
-}
+/** An entry on the undo stack records one reversible action. */
+type UndoEntry =
+  | { type: 'add' }
+  | { type: 'delete'; stroke: Stroke; index: number }
+
+/** An entry on the redo stack stores enough data to replay the action. */
+type RedoEntry =
+  | { type: 'add'; stroke: Stroke }
+  | { type: 'delete'; stroke: Stroke; index: number }
 
 export class StrokeManager {
   private strokes: Stroke[] = []
-  private redoStack: Stroke[] = []
+  private undoStack: UndoEntry[] = []
+  private redoStack: RedoEntry[] = []
   private currentStroke: Stroke | null = null
-  private lastDelete: DeleteRecord | null = null
 
   startStroke(point: Point): void {
     this.currentStroke = {
@@ -31,8 +36,8 @@ export class StrokeManager {
     }
     const stroke = this.currentStroke
     this.strokes.push(stroke)
+    this.undoStack.push({ type: 'add' })
     this.redoStack = []
-    this.lastDelete = null
     this.currentStroke = null
     return stroke
   }
@@ -46,29 +51,37 @@ export class StrokeManager {
   }
 
   undo(): Stroke | null {
-    // Undo a delete operation: restore the deleted stroke to its original position
-    if (this.lastDelete) {
-      const { stroke, index } = this.lastDelete
-      this.strokes.splice(index, 0, stroke)
-      this.lastDelete = null
+    const entry = this.undoStack.pop()
+    if (!entry) return null
+
+    if (entry.type === 'add') {
+      const stroke = this.strokes.pop()!
+      this.redoStack.push({ type: 'add', stroke })
       return stroke
+    } else {
+      this.strokes.splice(entry.index, 0, entry.stroke)
+      this.redoStack.push({ type: 'delete', stroke: entry.stroke, index: entry.index })
+      return entry.stroke
     }
-    const stroke = this.strokes.pop()
-    if (!stroke) return null
-    this.redoStack.push(stroke)
-    return stroke
   }
 
   redo(): Stroke | null {
-    const stroke = this.redoStack.pop()
-    if (!stroke) return null
-    this.strokes.push(stroke)
-    this.lastDelete = null
-    return stroke
+    const entry = this.redoStack.pop()
+    if (!entry) return null
+
+    if (entry.type === 'add') {
+      this.strokes.push(entry.stroke)
+      this.undoStack.push({ type: 'add' })
+      return entry.stroke
+    } else {
+      const [removed] = this.strokes.splice(entry.index, 1)
+      this.undoStack.push({ type: 'delete', stroke: removed, index: entry.index })
+      return removed
+    }
   }
 
   canUndo(): boolean {
-    return this.strokes.length > 0 || this.lastDelete !== null
+    return this.undoStack.length > 0
   }
 
   canRedo(): boolean {
@@ -78,8 +91,8 @@ export class StrokeManager {
   deleteStroke(index: number): Stroke | null {
     if (index < 0 || index >= this.strokes.length) return null
     const [removed] = this.strokes.splice(index, 1)
+    this.undoStack.push({ type: 'delete', stroke: removed, index })
     this.redoStack = []
-    this.lastDelete = { stroke: removed, index }
     return removed
   }
 
@@ -106,19 +119,21 @@ export class StrokeManager {
 
   loadState(strokes: Stroke[], redoStack: Stroke[]): void {
     this.strokes = [...strokes]
-    this.redoStack = [...redoStack]
-    this.lastDelete = null
+    this.undoStack = strokes.map(() => ({ type: 'add' as const }))
+    this.redoStack = redoStack.map(stroke => ({ type: 'add' as const, stroke }))
     this.currentStroke = null
   }
 
   getRedoStack(): readonly Stroke[] {
     return this.redoStack
+      .filter((e): e is RedoEntry & { type: 'add' } => e.type === 'add')
+      .map(e => e.stroke)
   }
 
   clear(): void {
     this.strokes = []
+    this.undoStack = []
     this.redoStack = []
-    this.lastDelete = null
     this.currentStroke = null
   }
 }

--- a/src/drawing/StrokeManager.ts
+++ b/src/drawing/StrokeManager.ts
@@ -1,9 +1,15 @@
 import type { Point, Stroke } from './types'
 
+interface DeleteRecord {
+  stroke: Stroke
+  index: number
+}
+
 export class StrokeManager {
   private strokes: Stroke[] = []
   private redoStack: Stroke[] = []
   private currentStroke: Stroke | null = null
+  private lastDelete: DeleteRecord | null = null
 
   startStroke(point: Point): void {
     this.currentStroke = {
@@ -26,6 +32,7 @@ export class StrokeManager {
     const stroke = this.currentStroke
     this.strokes.push(stroke)
     this.redoStack = []
+    this.lastDelete = null
     this.currentStroke = null
     return stroke
   }
@@ -39,6 +46,13 @@ export class StrokeManager {
   }
 
   undo(): Stroke | null {
+    // Undo a delete operation: restore the deleted stroke to its original position
+    if (this.lastDelete) {
+      const { stroke, index } = this.lastDelete
+      this.strokes.splice(index, 0, stroke)
+      this.lastDelete = null
+      return stroke
+    }
     const stroke = this.strokes.pop()
     if (!stroke) return null
     this.redoStack.push(stroke)
@@ -49,11 +63,12 @@ export class StrokeManager {
     const stroke = this.redoStack.pop()
     if (!stroke) return null
     this.strokes.push(stroke)
+    this.lastDelete = null
     return stroke
   }
 
   canUndo(): boolean {
-    return this.strokes.length > 0
+    return this.strokes.length > 0 || this.lastDelete !== null
   }
 
   canRedo(): boolean {
@@ -64,6 +79,7 @@ export class StrokeManager {
     if (index < 0 || index >= this.strokes.length) return null
     const [removed] = this.strokes.splice(index, 1)
     this.redoStack = []
+    this.lastDelete = { stroke: removed, index }
     return removed
   }
 
@@ -91,6 +107,7 @@ export class StrokeManager {
   loadState(strokes: Stroke[], redoStack: Stroke[]): void {
     this.strokes = [...strokes]
     this.redoStack = [...redoStack]
+    this.lastDelete = null
     this.currentStroke = null
   }
 
@@ -101,6 +118,7 @@ export class StrokeManager {
   clear(): void {
     this.strokes = []
     this.redoStack = []
+    this.lastDelete = null
     this.currentStroke = null
   }
 }


### PR DESCRIPTION
## Summary
- 消しゴムモードで、ハイライトされた線を再度タップすると直接削除できるように改善
- iPadでの操作時にツールバーまで手を移動する必要がなくなり、操作の移動量を削減
- ツールバーの削除/キャンセルボタンも引き続き使用可能
- StrokeManagerを統一undo/redo履歴に刷新：ストローク追加と削除を同列に管理し、時系列順にundo/redoが可能

Closes #48

## Test plan
- [x] 消しゴムモードで線をタップ → 赤くハイライトされることを確認
- [x] ハイライトされた線を再タップ → 削除されることを確認
- [x] 別の線をタップ → ハイライトがそちらに切り替わることを確認
- [x] 空白をタップ → ハイライトが解除されることを確認
- [x] ツールバーの削除ボタンでも削除できることを確認
- [x] undo で削除を取り消せることを確認
- [x] 連続で複数削除した後、undoで全て順番に復元されることを確認
- [x] 描画→削除→描画→undoが時系列の逆順で正しく動作することを確認
- [x] 削除のundoをredoで再削除できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)