### PR TITLE
feat: replace Unicode/emoji icons with Lucide icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm run lint       # Lint
 ## Tech Stack
 
 - React + TypeScript + Vite
-- Material-UI
+- Material-UI + Lucide Icons
 - Vitest + React Testing Library
 - Dexie.js (IndexedDB)
 - Sketchfab Viewer API / Data API

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^7.3.9",
         "dexie": "^4.4.1",
+        "lucide-react": "^1.8.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
@@ -3584,6 +3585,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.3.9",
     "dexie": "^4.4.1",
+    "lucide-react": "^1.8.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useCallback, useEffect } from 'react'
 import { Box, IconButton, Tooltip, Button, Typography } from '@mui/material'
+import { Pen, Eraser, Undo2, Redo2, Trash2, LocateFixed, Save, Check, Images } from 'lucide-react'
 import { DrawingCanvas, type DrawingMode } from './DrawingCanvas'
 import { StrokeManager } from '../drawing/StrokeManager'
 import { useGuides } from '../guides/useGuides'
@@ -140,10 +141,9 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
               bgcolor: mode === 'pen' ? 'primary.main' : 'transparent',
               color: mode === 'pen' ? 'white' : 'inherit',
               '&:hover': { bgcolor: mode === 'pen' ? 'primary.dark' : 'action.hover' },
-              fontSize: '1.2rem',
             }}
           >
-            &#9998;
+            <Pen size={20} />
           </IconButton>
         </Tooltip>
 
@@ -155,10 +155,9 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
               bgcolor: mode === 'eraser' ? 'error.main' : 'transparent',
               color: mode === 'eraser' ? 'white' : 'inherit',
               '&:hover': { bgcolor: mode === 'eraser' ? 'error.dark' : 'action.hover' },
-              fontSize: '1.2rem',
             }}
           >
-            &#9003;
+            <Eraser size={20} />
           </IconButton>
         </Tooltip>
 
@@ -168,7 +167,7 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
         <Tooltip title={t('undo')}>
           <span>
             <IconButton size="small" onClick={handleUndo} disabled={!canUndo}>
-              &#8630;
+              <Undo2 size={20} />
             </IconButton>
           </span>
         </Tooltip>
@@ -176,7 +175,7 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
         <Tooltip title={t('redo')}>
           <span>
             <IconButton size="small" onClick={handleRedo} disabled={!canRedo}>
-              &#8631;
+              <Redo2 size={20} />
             </IconButton>
           </span>
         </Tooltip>
@@ -184,7 +183,7 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
         <Tooltip title={t('clearAll')}>
           <span>
             <IconButton size="small" onClick={handleClear} disabled={strokeCount === 0}>
-              &#128465;
+              <Trash2 size={20} />
             </IconButton>
           </span>
         </Tooltip>
@@ -194,7 +193,7 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
         {/* View */}
         <Tooltip title={t('resetZoom')}>
           <IconButton size="small" onClick={() => setViewResetVersion(v => v + 1)}>
-            &#8858;
+            <LocateFixed size={20} />
           </IconButton>
         </Tooltip>
 
@@ -227,14 +226,14 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
                 transition: 'background-color 0.3s, color 0.3s',
               }}
             >
-              {saved ? '\u2714' : '\u{1F4BE}'}
+              {saved ? <Check size={20} /> : <Save size={20} />}
             </IconButton>
           </span>
         </Tooltip>
 
         <Tooltip title={t('gallery')}>
           <IconButton size="small" onClick={() => setShowGallery(true)}>
-            &#128444;
+            <Images size={20} />
           </IconButton>
         </Tooltip>
 

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Box, Typography, IconButton, Tooltip, Button } from '@mui/material'
+import { X, Trash2 } from 'lucide-react'
 import { getAllDrawings, deleteDrawing, type DrawingRecord } from '../storage'
 import { formatTime } from '../hooks/useTimer'
 import { t } from '../i18n'
@@ -95,7 +96,7 @@ export function Gallery({ onClose, onLoadReference }: GalleryProps) {
             {t('galleryTitle')} ({drawings.length})
           </Typography>
           <IconButton onClick={onClose} size="small">
-            &#10005;
+            <X size={20} />
           </IconButton>
         </Box>
 
@@ -160,7 +161,7 @@ export function Gallery({ onClose, onLoadReference }: GalleryProps) {
                             size="small"
                             onClick={() => drawing.id != null && handleDelete(drawing.id)}
                           >
-                            &#128465;
+                            <Trash2 size={20} />
                           </IconButton>
                         </Tooltip>
                       </Box>

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { Box, Button, Tooltip, IconButton, Typography, TextField } from '@mui/material'
+import { X, PenLine, CircleX, Trash2, Layers, FlipHorizontal2, LocateFixed, Maximize, Minimize } from 'lucide-react'
 import { SketchfabViewer, type SketchfabActions, type ReferenceInfo } from './SketchfabViewer'
 import { ImageViewer, type GuideInteractionMode } from './ImageViewer'
 import { useGuides } from '../guides/useGuides'
@@ -267,7 +268,7 @@ export function ReferencePanel({
         {!isNone && (
           <Tooltip title={t('cancel')}>
             <IconButton size="small" onClick={handleClose}>
-              &#10005;
+              <X size={20} />
             </IconButton>
           </Tooltip>
         )}
@@ -308,7 +309,7 @@ export function ReferencePanel({
                   '&:hover': { bgcolor: guideMode === 'add' ? 'error.dark' : 'action.hover' },
                 }}
               >
-                &#9999;
+                <PenLine size={20} />
               </IconButton>
             </Tooltip>
 
@@ -324,7 +325,7 @@ export function ReferencePanel({
                     '&:hover': { bgcolor: guideMode === 'delete' ? 'error.dark' : 'action.hover' },
                   }}
                 >
-                  &#10060;
+                  <CircleX size={20} />
                 </IconButton>
               </span>
             </Tooltip>
@@ -332,7 +333,7 @@ export function ReferencePanel({
             <Tooltip title={t('clearGuideLines')}>
               <span>
                 <IconButton size="small" onClick={clearLines} disabled={lines.length === 0}>
-                  &#128465;
+                  <Trash2 size={20} />
                 </IconButton>
               </span>
             </Tooltip>
@@ -366,7 +367,7 @@ export function ReferencePanel({
                 '&:hover': { bgcolor: overlayActive ? 'warning.dark' : 'action.hover' },
               }}
             >
-              &#9881;
+              <Layers size={20} />
             </IconButton>
           </Tooltip>
         )}
@@ -395,14 +396,14 @@ export function ReferencePanel({
               '&:hover': { bgcolor: isFlipped ? 'info.dark' : 'action.hover' },
             }}
           >
-            &#8646;
+            <FlipHorizontal2 size={20} />
           </IconButton>
         </Tooltip>
 
         {isFixed && (
           <Tooltip title={t('resetZoom')}>
             <IconButton size="small" onClick={() => setViewResetVersion(v => v + 1)}>
-              &#8858;
+              <LocateFixed size={20} />
             </IconButton>
           </Tooltip>
         )}
@@ -410,7 +411,7 @@ export function ReferencePanel({
         {fullscreenSupported && (
           <Tooltip title={isFullscreen ? t('exitFullscreen') : t('fullscreen')}>
             <IconButton size="small" onClick={toggleFullscreen}>
-              {isFullscreen ? '\u2716' : '\u26F6'}
+              {isFullscreen ? <Minimize size={20} /> : <Maximize size={20} />}
             </IconButton>
           </Tooltip>
         )}


### PR DESCRIPTION
## Summary

- **lucide-react** を導入し、全ツールバーアイコンをUnicode文字/絵文字から統一されたストロークベースSVGアイコンに置換
- 対象: DrawingPanel（9アイコン）、ReferencePanel（9アイコン）、Gallery（2アイコン）
- GridIconカスタムSVGとGitHubロゴSVGはそのまま維持
- README.md Tech Stackを更新

## Why

デバイスやブラウザによってUnicode文字の見た目が異なり、ツールバーの統一感がなかった。Lucideのストロークアイコンは既存のGridIconカスタムSVGとスタイルが調和し、一貫したUIを提供する。

## Test plan

- [x] `npm run lint` パス
- [x] `npm run build` パス
- [x] `npm run test` 全68テストパス
- [ ] `npm run dev` で各ボタンのアイコンが正しく表示されることを目視確認
- [ ] アクティブ状態（白色反転）、disabled状態が正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)