### PR TITLE
feat: pause timer on save and auto-resume on next stroke

### DIFF
--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -112,10 +112,11 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
     setSaving(true)
     const thumbnail = generateThumbnail(strokes)
     await saveDrawing(strokes, thumbnail, referenceInfo ?? null, timer.elapsedMs)
+    timer.pause()
     setSaving(false)
     setSaved(true)
     setTimeout(() => setSaved(false), 2000)
-  }, [referenceInfo, timer.elapsedMs])
+  }, [referenceInfo, timer])
 
   return (
     <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>


### PR DESCRIPTION
## Summary
- 保存ボタン押下時に `timer.pause()` を呼び出してタイマーを停止
- 次のストローク追加・undo・redo・消しゴム操作で既存の `handleStrokeCountChange` ロジックによりタイマーが自動再開
- 経過時間はリセットされず、蓄積時間から継続

## Test plan
- [ ] ストロークを描いてタイマーが開始されることを確認
- [ ] 保存ボタンを押してタイマーが停止することを確認
- [ ] 新しいストロークを描いてタイマーが再開（リセットではなく継続）されることを確認
- [ ] undo/redo操作でもタイマーが再開されることを確認
- [ ] `npm run test` パス済み、`npm run lint` パス済み、`npm run build` パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)