### PR TITLE
chore: add cooldown and vitest to spell check dictionary

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,11 @@
 {
     "cSpell.words": [
+        "cooldown",
         "dexie",
         "Sketchfab",
         "trackpad",
         "undoable",
-        "viewerready"
+        "viewerready",
+        "vitest"
     ]
 }


### PR DESCRIPTION
## Summary
- Add `cooldown` and `vitest` to the VS Code cSpell dictionary so they no longer get flagged in the editor.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)