### PR TITLE
feat: make reference info overlay collapsible (closes #75)

### DIFF
--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -85,6 +85,10 @@ function ReferenceInfoOverlay({ refInfo }: { refInfo: ReferenceInfo }) {
       position: 'absolute',
       bottom: 8,
       left: 8,
+      // Cap the overall overlay width so long titles / author lines can't
+      // push the collapse button off-screen on narrow viewports. The 16px
+      // budget accounts for the 8px left offset plus an 8px right gutter.
+      maxWidth: 'calc(100% - 16px)',
       zIndex: 5,
       pointerEvents: 'none',
     }}>
@@ -116,7 +120,6 @@ function ReferenceInfoOverlay({ refInfo }: { refInfo: ReferenceInfo }) {
           pr: 0.5,
           py: 0.5,
           borderRadius: 1,
-          maxWidth: '80%',
         }}>
           <Box sx={{ flex: 1, minWidth: 0 }}>
             {refInfo.title && (

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { Box, Button, Tooltip, IconButton, Typography, TextField, Link as MuiLink } from '@mui/material'
-import { X, PenLine, CircleX, Trash2, Layers, FlipHorizontal2, LocateFixed, Maximize, Minimize, Settings } from 'lucide-react'
+import { X, PenLine, CircleX, Trash2, Layers, FlipHorizontal2, LocateFixed, Maximize, Minimize, Settings, Info } from 'lucide-react'
 import { SketchfabViewer, type SketchfabActions } from './SketchfabViewer'
 import { ImageViewer, type GuideInteractionMode } from './ImageViewer'
 import { YouTubeViewer } from './YouTubeViewer'
@@ -19,7 +19,7 @@ import type { GridMode } from '../guides/types'
 import { useFullscreen } from '../hooks/useFullscreen'
 import { t } from '../i18n'
 import type { Stroke } from '../drawing/types'
-import type { ReferenceSource, ReferenceMode, ReferenceInfo } from '../types'
+import { referenceKey, type ReferenceSource, type ReferenceMode, type ReferenceInfo } from '../types'
 
 /**
  * Raw setters for the reference-related state living in SplitLayout. Exposed
@@ -68,6 +68,101 @@ function GridIcon({ mode }: { mode: GridMode }) {
       <line x1="10" y1="1" x2="10" y2="19" strokeWidth="2" />
       <line x1="1" y1="10" x2="19" y2="10" strokeWidth="2" />
     </svg>
+  )
+}
+
+/**
+ * Reference-source attribution pill shown over the bottom-left of the
+ * reference image. Collapses to a small info icon on user tap so it doesn't
+ * cover the lower portion of the reference while drawing. Parent keys this
+ * component by reference identity, so a new reference remounts it in the
+ * expanded state.
+ */
+function ReferenceInfoOverlay({ refInfo }: { refInfo: ReferenceInfo }) {
+  const [collapsed, setCollapsed] = useState(false)
+  return (
+    <Box sx={{
+      position: 'absolute',
+      bottom: 8,
+      left: 8,
+      zIndex: 5,
+      pointerEvents: 'none',
+    }}>
+      {collapsed ? (
+        <Tooltip title={t('expandReferenceInfo')}>
+          <IconButton
+            size="small"
+            onClick={() => setCollapsed(false)}
+            aria-label={t('expandReferenceInfo')}
+            sx={{
+              pointerEvents: 'auto',
+              bgcolor: 'rgba(0,0,0,0.5)',
+              color: 'white',
+              '&:hover': { bgcolor: 'rgba(0,0,0,0.7)' },
+            }}
+          >
+            <Info size={18} />
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <Box sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 0.5,
+          pointerEvents: 'auto',
+          bgcolor: 'rgba(0,0,0,0.5)',
+          color: 'white',
+          pl: 1,
+          pr: 0.5,
+          py: 0.5,
+          borderRadius: 1,
+          maxWidth: '80%',
+        }}>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            {refInfo.title && (
+              <Typography variant="caption" sx={{ display: 'block', fontWeight: 'bold', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {refInfo.title}
+              </Typography>
+            )}
+            {refInfo.author && (
+              <Typography variant="caption" sx={{ display: 'block', opacity: 0.9, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {refInfo.source === 'pexels' && refInfo.pexelsPhotographerUrl ? (
+                  <>
+                    {t('pexelsPhotoBy')}{' '}
+                    <MuiLink href={refInfo.pexelsPhotographerUrl} target="_blank" rel="noopener noreferrer" sx={{ color: 'inherit', textDecoration: 'underline' }}>
+                      {refInfo.author}
+                    </MuiLink>
+                    {refInfo.pexelsPageUrl && (
+                      <>
+                        {' · '}
+                        <MuiLink href={refInfo.pexelsPageUrl} target="_blank" rel="noopener noreferrer" sx={{ color: 'inherit', textDecoration: 'underline' }}>
+                          {t('pexelsViaPexels')}
+                        </MuiLink>
+                      </>
+                    )}
+                  </>
+                ) : refInfo.author}
+              </Typography>
+            )}
+          </Box>
+          <Tooltip title={t('collapseReferenceInfo')}>
+            <IconButton
+              size="small"
+              onClick={() => setCollapsed(true)}
+              aria-label={t('collapseReferenceInfo')}
+              sx={{
+                flexShrink: 0,
+                color: 'white',
+                p: 0.25,
+                '&:hover': { bgcolor: 'rgba(255,255,255,0.15)' },
+              }}
+            >
+              <X size={14} />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      )}
+    </Box>
   )
 }
 
@@ -654,45 +749,10 @@ export function ReferencePanel({
 
         {/* Reference info overlay */}
         {isFixed && refInfo && (refInfo.title || refInfo.author) && (
-          <Box sx={{
-            position: 'absolute',
-            bottom: 8,
-            left: 8,
-            zIndex: 5,
-            bgcolor: 'rgba(0,0,0,0.5)',
-            color: 'white',
-            px: 1,
-            py: 0.5,
-            borderRadius: 1,
-            maxWidth: '80%',
-            pointerEvents: refInfo.source === 'pexels' && (refInfo.pexelsPhotographerUrl || refInfo.pexelsPageUrl) ? 'auto' : 'none',
-          }}>
-            {refInfo.title && (
-              <Typography variant="caption" sx={{ display: 'block', fontWeight: 'bold', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {refInfo.title}
-              </Typography>
-            )}
-            {refInfo.author && (
-              <Typography variant="caption" sx={{ display: 'block', opacity: 0.9, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {refInfo.source === 'pexels' && refInfo.pexelsPhotographerUrl ? (
-                  <>
-                    {t('pexelsPhotoBy')}{' '}
-                    <MuiLink href={refInfo.pexelsPhotographerUrl} target="_blank" rel="noopener noreferrer" sx={{ color: 'inherit', textDecoration: 'underline' }}>
-                      {refInfo.author}
-                    </MuiLink>
-                    {refInfo.pexelsPageUrl && (
-                      <>
-                        {' · '}
-                        <MuiLink href={refInfo.pexelsPageUrl} target="_blank" rel="noopener noreferrer" sx={{ color: 'inherit', textDecoration: 'underline' }}>
-                          {t('pexelsViaPexels')}
-                        </MuiLink>
-                      </>
-                    )}
-                  </>
-                ) : refInfo.author}
-              </Typography>
-            )}
-          </Box>
+          <ReferenceInfoOverlay
+            key={referenceKey(refInfo)}
+            refInfo={refInfo}
+          />
         )}
 
         {/* Fixed image */}

--- a/src/components/SplitLayout.test.tsx
+++ b/src/components/SplitLayout.test.tsx
@@ -17,6 +17,29 @@ vi.mock('../utils/pexels', async () => {
   }
 })
 
+function pexelsPhoto(id: number, photographer: string) {
+  return {
+    id,
+    width: 1920,
+    height: 1280,
+    url: `https://www.pexels.com/photo/sample-${id}/`,
+    photographer,
+    photographer_url: `https://www.pexels.com/@${photographer.toLowerCase().replace(/\s+/g, '-')}`,
+    photographer_id: 1,
+    alt: 'A sample pose',
+    src: {
+      original: `https://images.pexels.com/photos/${id}/pexels-photo-${id}.jpeg`,
+      large2x: `https://images.pexels.com/photos/${id}/pexels-photo-${id}.jpeg?w=1880`,
+      large: '',
+      medium: '',
+      small: '',
+      portrait: '',
+      landscape: '',
+      tiny: '',
+    },
+  }
+}
+
 describe('SplitLayout', () => {
   it('renders both panels', () => {
     render(<SplitLayout />)
@@ -165,26 +188,7 @@ describe('SplitLayout', () => {
     })
 
     it('detects a Pexels URL in the URL field and switches to Pexels reference', async () => {
-      getPhotoMock.mockResolvedValueOnce({
-        id: 12345,
-        width: 1920,
-        height: 1280,
-        url: 'https://www.pexels.com/photo/sample-12345/',
-        photographer: 'Alice Photographer',
-        photographer_url: 'https://www.pexels.com/@alice',
-        photographer_id: 1,
-        alt: 'A sample pose',
-        src: {
-          original: 'https://images.pexels.com/photos/12345/pexels-photo-12345.jpeg',
-          large2x: 'https://images.pexels.com/photos/12345/pexels-photo-12345.jpeg?w=1880',
-          large: '',
-          medium: '',
-          small: '',
-          portrait: '',
-          landscape: '',
-          tiny: '',
-        },
-      })
+      getPhotoMock.mockResolvedValueOnce(pexelsPhoto(12345, 'Alice Photographer'))
 
       const { container } = render(<SplitLayout />)
       expect(undoBtn(container)).toBeDisabled()
@@ -201,6 +205,70 @@ describe('SplitLayout', () => {
 
       fireEvent.click(undoBtn(container))
       expect(screen.getByText('Image File')).toBeInTheDocument()
+    })
+  })
+
+  describe('reference info overlay collapse', () => {
+    async function loadPexels(id: number, photographer: string) {
+      getPhotoMock.mockResolvedValueOnce(pexelsPhoto(id, photographer))
+      const urlInput = screen.getByPlaceholderText(/Pexels/i) as HTMLInputElement
+      fireEvent.change(urlInput, { target: { value: `https://www.pexels.com/photo/sample-${id}/` } })
+      fireEvent.click(screen.getByText('Load'))
+      await waitFor(() => expect(screen.getByText(photographer)).toBeInTheDocument())
+    }
+
+    it('collapses the overlay when the collapse button is clicked', async () => {
+      render(<SplitLayout />)
+      await loadPexels(12345, 'Alice Photographer')
+
+      fireEvent.click(screen.getByLabelText('Collapse info'))
+
+      expect(screen.queryByText('Alice Photographer')).not.toBeInTheDocument()
+      expect(screen.getByLabelText('Show info')).toBeInTheDocument()
+    })
+
+    it('re-expands the overlay when the info icon is clicked', async () => {
+      render(<SplitLayout />)
+      await loadPexels(12345, 'Alice Photographer')
+
+      fireEvent.click(screen.getByLabelText('Collapse info'))
+      expect(screen.queryByText('Alice Photographer')).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByLabelText('Show info'))
+      expect(screen.getByText('Alice Photographer')).toBeInTheDocument()
+      expect(screen.getByLabelText('Collapse info')).toBeInTheDocument()
+    })
+
+    it('keeps the photographer link clickable while expanded', async () => {
+      render(<SplitLayout />)
+      await loadPexels(12345, 'Alice Photographer')
+
+      const link = screen.getByText('Alice Photographer').closest('a') as HTMLAnchorElement
+      expect(link).not.toBeNull()
+      expect(link.href).toBe('https://www.pexels.com/@alice-photographer')
+      expect(link.target).toBe('_blank')
+    })
+
+    it('re-expands automatically when a new reference is loaded', async () => {
+      const { container } = render(<SplitLayout />)
+      await loadPexels(12345, 'Alice Photographer')
+
+      fireEvent.click(screen.getByLabelText('Collapse info'))
+      expect(screen.getByLabelText('Show info')).toBeInTheDocument()
+
+      // Close the reference (toolbar X is the first lucide-x in DOM order —
+      // the collapsed overlay shows Info, not X, so no ambiguity).
+      const closeIcon = container.querySelector('svg.lucide-x')
+      if (!closeIcon) throw new Error('toolbar close icon not found')
+      fireEvent.click(closeIcon.closest('button')!)
+      await waitFor(() => expect(screen.getByText('Image File')).toBeInTheDocument())
+
+      // Load a different Pexels photo — overlay should mount fresh (expanded).
+      await loadPexels(67890, 'Bob Photographer')
+
+      expect(screen.getByText('Bob Photographer')).toBeInTheDocument()
+      expect(screen.getByLabelText('Collapse info')).toBeInTheDocument()
+      expect(screen.queryByLabelText('Show info')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -85,6 +85,8 @@ const messages = {
     'pexelsPhotoBy': 'Photo by',
     'pexelsViaPexels': 'via Pexels',
     'pexelsBackToSearch': 'Back to search',
+    'collapseReferenceInfo': 'Collapse info',
+    'expandReferenceInfo': 'Show info',
   },
   ja: {
     // DrawingPanel
@@ -172,6 +174,8 @@ const messages = {
     'pexelsPhotoBy': '撮影:',
     'pexelsViaPexels': 'via Pexels',
     'pexelsBackToSearch': '検索に戻る',
+    'collapseReferenceInfo': '情報を畳む',
+    'expandReferenceInfo': '情報を表示',
   },
 } as const
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,3 +38,20 @@ export type ReferenceInfo =
       pexelsPhotographerUrl?: string
       pexelsPageUrl?: string
     })
+
+/**
+ * Stable identity key for a reference. Used as a React `key` so that
+ * reference-scoped UI state remounts when the user switches to a different
+ * reference. Keyed on the per-variant unique identifier rather than on
+ * title/author, so two different items that happen to share metadata do not
+ * collide.
+ */
+export function referenceKey(info: ReferenceInfo): string {
+  switch (info.source) {
+    case 'sketchfab': return `sketchfab:${info.sketchfabUid}`
+    case 'image': return `image:${info.fileName}`
+    case 'url': return `url:${info.imageUrl}`
+    case 'youtube': return `youtube:${info.youtubeVideoId}`
+    case 'pexels': return `pexels:${info.pexelsPhotoId}`
+  }
+}


### PR DESCRIPTION
## Summary
- Reference-source attribution pill over the reference image is now collapsible — tap the inline X to shrink it to a small info icon, tap the icon to re-expand.
- Overlay state is per-reference: loading a different reference remounts the overlay in the expanded state (keyed on a new `referenceKey(refInfo)` helper in `types.ts`, so two distinct items never collide even if title/author match).
- Pexels photographer / page links remain clickable while expanded.

Closes #75.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (161/161 — 4 new tests covering collapse, re-expand, link clickability, remount-on-new-reference)
- [x] `npm run build`
- [ ] Manual: load each source (Sketchfab / local image / URL / Pexels) in fixed mode and verify collapse/expand
- [x] Manual: verify the lower portion of the reference is reachable while overlay is collapsed
- [x] Manual: verify Pexels photographer / Pexels page links are clickable
- [x] Manual: verify loading a new reference auto-expands (doesn't stay collapsed)
- [x] Manual: portrait + landscape layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)