### PR TITLE
feat: add URL history dropdown to reference URL input

### DIFF
--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { Box, Button, Tooltip, IconButton, Typography, TextField, Link as MuiLink } from '@mui/material'
-import { X, PenLine, CircleX, Trash2, Layers, FlipHorizontal2, LocateFixed, Maximize, Minimize, Settings, Info } from 'lucide-react'
+import { Box, Button, Tooltip, IconButton, Typography, TextField, Link as MuiLink, Autocomplete } from '@mui/material'
+import { X, PenLine, CircleX, Trash2, Layers, FlipHorizontal2, LocateFixed, Maximize, Minimize, Settings, Info, Film, Camera, Image as ImageIcon } from 'lucide-react'
 import { SketchfabViewer, type SketchfabActions } from './SketchfabViewer'
 import { ImageViewer, type GuideInteractionMode } from './ImageViewer'
 import type { ViewTransform } from '../drawing/ViewTransform'
@@ -8,13 +8,42 @@ import { YouTubeViewer } from './YouTubeViewer'
 import { PexelsSearcher } from './PexelsSearcher'
 import { PexelsApiKeyDialog } from './PexelsApiKeyDialog'
 import { GitHubIcon } from './GitHubIcon'
-import { parseYouTubeVideoId } from '../utils/youtube'
+import { parseYouTubeVideoId, fetchYouTubeTitle } from '../utils/youtube'
 import {
   buildPexelsReferenceInfo,
   getPhoto,
   mapPexelsErrorKey,
   parsePexelsPhotoUrl,
 } from '../utils/pexels'
+import { addUrlHistory, getUrlHistory, deleteUrlHistory, type UrlHistoryEntry, type UrlHistoryType } from '../storage'
+
+function describeHistoryUrl(entry: UrlHistoryEntry): { primary: string; secondary: string } {
+  if (entry.title) return { primary: entry.title, secondary: entry.url }
+  if (entry.type === 'youtube') {
+    const id = parseYouTubeVideoId(entry.url)
+    return { primary: id ? `YouTube · ${id}` : entry.url, secondary: entry.url }
+  }
+  let parsed: URL
+  try {
+    parsed = new URL(entry.url)
+  } catch {
+    return { primary: entry.url, secondary: '' }
+  }
+  const segments = parsed.pathname.split('/').filter(Boolean)
+  if (entry.type === 'pexels') {
+    const photoIndex = segments.indexOf('photo')
+    const slug = photoIndex >= 0 ? segments[photoIndex + 1] : undefined
+    return { primary: slug ? `Pexels · ${slug}` : entry.url, secondary: entry.url }
+  }
+  const filename = segments.pop()
+  return { primary: filename || parsed.hostname, secondary: parsed.hostname }
+}
+
+function HistoryTypeIcon({ type }: { type: UrlHistoryType }) {
+  if (type === 'youtube') return <Film size={14} />
+  if (type === 'pexels') return <Camera size={14} />
+  return <ImageIcon size={14} />
+}
 import { useGuides } from '../guides/useGuides'
 import type { GridMode } from '../guides/types'
 import { useFullscreen } from '../hooks/useFullscreen'
@@ -211,6 +240,15 @@ export function ReferencePanel({
   const [highlightedGuideId, setHighlightedGuideId] = useState<string | null>(null)
   const [urlInput, setUrlInput] = useState('')
   const [urlError, setUrlError] = useState<string | null>(null)
+  const [urlHistory, setUrlHistory] = useState<UrlHistoryEntry[]>([])
+
+  const reloadUrlHistory = useCallback(() => {
+    getUrlHistory().then(setUrlHistory).catch(() => { /* ignore storage errors */ })
+  }, [])
+
+  useEffect(() => {
+    reloadUrlHistory()
+  }, [reloadUrlHistory])
 
   // Sketchfab viewer state (reported by child)
   const [sfShowViewer, setSfShowViewer] = useState(false)
@@ -281,6 +319,11 @@ export function ReferencePanel({
       })
       setUrlInput('')
       setUrlLoading(false)
+      fetchYouTubeTitle(ytId)
+        .catch(() => null)
+        .then(title => addUrlHistory(url, 'youtube', title ?? undefined))
+        .then(reloadUrlHistory)
+        .catch(() => { /* ignore */ })
       return
     }
 
@@ -298,6 +341,7 @@ export function ReferencePanel({
             s.setReferenceInfo(info)
           })
           setUrlInput('')
+          addUrlHistory(url, 'pexels', info.title).then(reloadUrlHistory).catch(() => { /* ignore */ })
         })
         .catch(e => setUrlError(t(mapPexelsErrorKey(e))))
         .finally(() => setUrlLoading(false))
@@ -321,6 +365,7 @@ export function ReferencePanel({
         s.setReferenceMode('fixed')
       })
       setUrlInput('')
+      addUrlHistory(url, 'url').then(reloadUrlHistory).catch(() => { /* ignore */ })
     }
 
     // Preload image: try CORS first, then without, check naturalWidth
@@ -338,7 +383,7 @@ export function ReferencePanel({
       retry.src = url
     }
     img.src = url
-  }, [onReferenceChange])
+  }, [onReferenceChange, reloadUrlHistory])
 
   const handleFixAngle = useCallback((screenshotUrl: string, info: ReferenceInfo) => {
     onReferenceChange(s => {
@@ -674,14 +719,79 @@ export function ReferencePanel({
               </Box>
             </Box>
             <Box sx={{ display: 'flex', gap: 1, width: '80%', maxWidth: 400 }}>
-              <TextField
+              <Autocomplete<UrlHistoryEntry, false, false, true>
+                freeSolo
                 size="small"
-                placeholder={t('urlPlaceholder')}
-                value={urlInput}
-                onChange={e => { setUrlInput(e.target.value); setUrlError(null) }}
-                onKeyDown={e => { if (e.key === 'Enter' && urlInput) handleLoadFromUrl(urlInput) }}
                 sx={{ flex: 1 }}
                 fullWidth
+                options={urlHistory}
+                filterOptions={x => x}
+                getOptionLabel={option => typeof option === 'string' ? option : option.url}
+                isOptionEqualToValue={(a, b) => a.url === b.url}
+                inputValue={urlInput}
+                onInputChange={(_, value, reason) => {
+                  if (reason === 'input' || reason === 'clear') {
+                    setUrlInput(value)
+                    setUrlError(null)
+                  }
+                }}
+                onChange={(_, value, reason) => {
+                  if (reason === 'selectOption' && value && typeof value !== 'string') {
+                    setUrlInput(value.url)
+                    setUrlError(null)
+                    handleLoadFromUrl(value.url)
+                  }
+                }}
+                renderOption={(props, option) => {
+                  const { key, ...rest } = props as typeof props & { key: string }
+                  const { primary, secondary } = describeHistoryUrl(option)
+                  return (
+                    <li key={key} {...rest} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <Box component="span" sx={{ color: 'text.secondary', display: 'inline-flex' }}>
+                        <HistoryTypeIcon type={option.type} />
+                      </Box>
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Typography variant="body2" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {primary}
+                        </Typography>
+                        {secondary && (
+                          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            {secondary}
+                          </Typography>
+                        )}
+                      </Box>
+                      <Tooltip title={t('urlHistoryDelete')}>
+                        <IconButton
+                          size="small"
+                          aria-label={t('urlHistoryDelete')}
+                          // Touch devices commit option selection on pointerdown
+                          // (before click), so we have to stop propagation there
+                          // too — not just on click.
+                          onPointerDown={e => { e.stopPropagation(); e.preventDefault() }}
+                          onClick={e => {
+                            e.stopPropagation()
+                            deleteUrlHistory(option.url).then(reloadUrlHistory).catch(() => { /* ignore */ })
+                          }}
+                        >
+                          <Trash2 size={14} />
+                        </IconButton>
+                      </Tooltip>
+                    </li>
+                  )
+                }}
+                renderInput={params => (
+                  <TextField
+                    {...params}
+                    size="small"
+                    placeholder={t('urlPlaceholder')}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' && urlInput) {
+                        e.preventDefault()
+                        handleLoadFromUrl(urlInput)
+                      }
+                    }}
+                  />
+                )}
               />
               <Button
                 size="small"

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -63,6 +63,7 @@ const messages = {
     'urlPlaceholder': 'Image, YouTube, or Pexels URL...',
     'loadUrl': 'Load',
     'urlLoadFailed': 'Failed to load image from URL.',
+    'urlHistoryDelete': 'Remove from history',
     'autosaveDisabled': 'Autosave is disabled because another tab is active. Changes in this tab will not be saved automatically.',
 
     // Pexels
@@ -152,6 +153,7 @@ const messages = {
     'urlPlaceholder': '画像・YouTube・PexelsのURL...',
     'loadUrl': '読込',
     'urlLoadFailed': 'URLからの画像の読み込みに失敗しました。',
+    'urlHistoryDelete': '履歴から削除',
     'autosaveDisabled': '別のタブが開いているため、オートセーブが無効です。このタブの変更は自動保存されません。',
 
     // Pexels

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -28,6 +28,15 @@ export interface SessionDraft {
   updatedAt: Date
 }
 
+export type UrlHistoryType = 'youtube' | 'pexels' | 'url'
+
+export interface UrlHistoryEntry {
+  url: string
+  type: UrlHistoryType
+  title?: string
+  lastUsedAt: Date
+}
+
 // Scope database name by deploy path so PR previews don't share data.
 // Keep the original name for the main deployment to preserve existing data.
 const DB_BASE_NAME = 'DrawingPracticeDB'
@@ -39,6 +48,7 @@ const dbName = isMainDeployment ? DB_BASE_NAME : `${PR_DB_PREFIX}${basePath}`
 const db = new Dexie(dbName) as Dexie & {
   drawings: EntityTable<DrawingRecord, 'id'>
   session: EntityTable<SessionDraft, 'id'>
+  urlHistory: EntityTable<UrlHistoryEntry, 'url'>
 }
 
 db.version(1).stores({
@@ -52,6 +62,12 @@ db.version(2).stores({
 db.version(3).stores({
   drawings: '++id, createdAt',
   session: 'id',
+})
+
+db.version(4).stores({
+  drawings: '++id, createdAt',
+  session: 'id',
+  urlHistory: 'url, lastUsedAt',
 })
 
 export { db }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,4 +1,5 @@
 export { saveDrawing, getAllDrawings, getDrawing, deleteDrawing, getDrawingCount } from './drawingStore'
 export { saveDraft, loadDraft, clearDraft } from './sessionStore'
-export type { DrawingRecord, SessionDraft } from './db'
+export { addUrlHistory, getUrlHistory, deleteUrlHistory, URL_HISTORY_LIMIT } from './urlHistoryStore'
+export type { DrawingRecord, SessionDraft, UrlHistoryEntry, UrlHistoryType } from './db'
 export type { DraftData } from './sessionStore'

--- a/src/storage/urlHistoryStore.test.ts
+++ b/src/storage/urlHistoryStore.test.ts
@@ -1,0 +1,156 @@
+import { vi, type Mock } from 'vitest'
+import type { UrlHistoryEntry } from './db'
+
+const { orderedToArrayFn } = vi.hoisted(() => ({
+  orderedToArrayFn: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('./db', () => ({
+  db: {
+    urlHistory: {
+      put: vi.fn().mockResolvedValue(undefined),
+      get: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      bulkDelete: vi.fn().mockResolvedValue(undefined),
+      toArray: vi.fn().mockResolvedValue([]),
+      orderBy: vi.fn(() => ({ reverse: () => ({ toArray: orderedToArrayFn }) })),
+    },
+  },
+}))
+
+import { addUrlHistory, getUrlHistory, deleteUrlHistory, URL_HISTORY_LIMIT } from './urlHistoryStore'
+import { db } from './db'
+
+const mockToArray = () => db.urlHistory.toArray as Mock
+const mockPut = () => db.urlHistory.put as Mock
+const mockGet = () => db.urlHistory.get as Mock
+const mockBulkDelete = () => db.urlHistory.bulkDelete as Mock
+const mockDelete = () => db.urlHistory.delete as Mock
+const mockOrderBy = () => db.urlHistory.orderBy as Mock
+
+describe('urlHistoryStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockToArray().mockResolvedValue([])
+    mockGet().mockResolvedValue(undefined)
+    orderedToArrayFn.mockResolvedValue([])
+  })
+
+  describe('addUrlHistory', () => {
+    it('puts an entry with current timestamp', async () => {
+      const before = Date.now()
+      await addUrlHistory('https://example.com/a.jpg', 'url')
+      const after = Date.now()
+
+      expect(mockPut()).toHaveBeenCalledTimes(1)
+      const arg = mockPut().mock.calls[0][0] as UrlHistoryEntry
+      expect(arg.url).toBe('https://example.com/a.jpg')
+      expect(arg.type).toBe('url')
+      expect(arg.lastUsedAt).toBeInstanceOf(Date)
+      expect(arg.lastUsedAt.getTime()).toBeGreaterThanOrEqual(before)
+      expect(arg.lastUsedAt.getTime()).toBeLessThanOrEqual(after)
+    })
+
+    it('uses put so duplicate URL upserts without adding a second row', async () => {
+      // Dexie's put is an upsert keyed by the primary key. Verify we call put
+      // (not add) so a re-loaded URL simply refreshes its lastUsedAt.
+      await addUrlHistory('https://example.com/a.jpg', 'url')
+      await addUrlHistory('https://example.com/a.jpg', 'url')
+      expect(mockPut()).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not prune when count is at or below the limit', async () => {
+      const entries: UrlHistoryEntry[] = Array.from({ length: URL_HISTORY_LIMIT }, (_, i) => ({
+        url: `https://example.com/${i}`,
+        type: 'url',
+        lastUsedAt: new Date(1000 + i),
+      }))
+      mockToArray().mockResolvedValue(entries)
+
+      await addUrlHistory('https://example.com/new', 'url')
+
+      expect(mockBulkDelete()).not.toHaveBeenCalled()
+    })
+
+    it('stores the title when provided', async () => {
+      await addUrlHistory('https://youtu.be/abc', 'youtube', '  Great Video  ')
+      const arg = mockPut().mock.calls[0][0] as UrlHistoryEntry
+      expect(arg.title).toBe('Great Video')
+    })
+
+    it('preserves an existing title when called again without a title', async () => {
+      mockGet().mockResolvedValueOnce({
+        url: 'https://youtu.be/abc',
+        type: 'youtube',
+        title: 'Cached Title',
+        lastUsedAt: new Date(1000),
+      })
+      await addUrlHistory('https://youtu.be/abc', 'youtube')
+      const arg = mockPut().mock.calls[0][0] as UrlHistoryEntry
+      expect(arg.title).toBe('Cached Title')
+    })
+
+    it('overwrites the title when a new title is provided', async () => {
+      // No need to mock `get` — when a title is passed in, the store should
+      // skip the existing-title lookup entirely.
+      await addUrlHistory('https://youtu.be/abc', 'youtube', 'New Title')
+      expect(mockGet()).not.toHaveBeenCalled()
+      const arg = mockPut().mock.calls[0][0] as UrlHistoryEntry
+      expect(arg.title).toBe('New Title')
+    })
+
+    it('omits title when none is provided and none exists', async () => {
+      mockGet().mockResolvedValueOnce(undefined)
+      await addUrlHistory('https://example.com/a.jpg', 'url')
+      const arg = mockPut().mock.calls[0][0] as UrlHistoryEntry
+      expect(arg.title).toBeUndefined()
+    })
+
+    it('deletes the oldest entries when count exceeds the limit', async () => {
+      const overLimit = URL_HISTORY_LIMIT + 3
+      const entries: UrlHistoryEntry[] = Array.from({ length: overLimit }, (_, i) => ({
+        url: `https://example.com/${i}`,
+        type: 'url',
+        lastUsedAt: new Date(1000 + i),  // i=0 is oldest
+      }))
+      mockToArray().mockResolvedValue(entries)
+
+      await addUrlHistory('https://example.com/new', 'url')
+
+      expect(mockBulkDelete()).toHaveBeenCalledTimes(1)
+      const deletedUrls = mockBulkDelete().mock.calls[0][0] as string[]
+      expect(deletedUrls).toHaveLength(3)
+      expect(deletedUrls).toEqual([
+        'https://example.com/0',
+        'https://example.com/1',
+        'https://example.com/2',
+      ])
+    })
+  })
+
+  describe('getUrlHistory', () => {
+    it('queries the lastUsedAt index in reverse order', async () => {
+      const entries: UrlHistoryEntry[] = [
+        { url: 'newest', type: 'youtube', lastUsedAt: new Date(3000) },
+        { url: 'mid', type: 'pexels', lastUsedAt: new Date(2000) },
+        { url: 'old', type: 'url', lastUsedAt: new Date(1000) },
+      ]
+      orderedToArrayFn.mockResolvedValueOnce(entries)
+
+      const result = await getUrlHistory()
+      expect(mockOrderBy()).toHaveBeenCalledWith('lastUsedAt')
+      expect(result).toEqual(entries)
+    })
+
+    it('returns an empty array when there is no history', async () => {
+      expect(await getUrlHistory()).toEqual([])
+    })
+  })
+
+  describe('deleteUrlHistory', () => {
+    it('deletes the entry by url key', async () => {
+      await deleteUrlHistory('https://example.com/a.jpg')
+      expect(mockDelete()).toHaveBeenCalledWith('https://example.com/a.jpg')
+    })
+  })
+})

--- a/src/storage/urlHistoryStore.ts
+++ b/src/storage/urlHistoryStore.ts
@@ -1,0 +1,33 @@
+import { db, type UrlHistoryEntry, type UrlHistoryType } from './db'
+
+export const URL_HISTORY_LIMIT = 50
+
+/**
+ * Upsert a history entry. If `title` is omitted but an existing entry has one,
+ * the old title is preserved so a late or failed title fetch doesn't clobber
+ * what we already knew.
+ */
+export async function addUrlHistory(url: string, type: UrlHistoryType, title?: string): Promise<void> {
+  let finalTitle = title?.trim() || undefined
+  if (!finalTitle) {
+    const existing = await db.urlHistory.get(url)
+    finalTitle = existing?.title
+  }
+  const entry: UrlHistoryEntry = { url, type, lastUsedAt: new Date() }
+  if (finalTitle) entry.title = finalTitle
+  await db.urlHistory.put(entry)
+  const all = await db.urlHistory.toArray()
+  if (all.length > URL_HISTORY_LIMIT) {
+    const sorted = [...all].sort((a, b) => a.lastUsedAt.getTime() - b.lastUsedAt.getTime())
+    const excess = sorted.slice(0, all.length - URL_HISTORY_LIMIT)
+    await db.urlHistory.bulkDelete(excess.map(e => e.url))
+  }
+}
+
+export async function getUrlHistory(): Promise<UrlHistoryEntry[]> {
+  return db.urlHistory.orderBy('lastUsedAt').reverse().toArray()
+}
+
+export async function deleteUrlHistory(url: string): Promise<void> {
+  await db.urlHistory.delete(url)
+}

--- a/src/utils/youtube.test.ts
+++ b/src/utils/youtube.test.ts
@@ -1,4 +1,5 @@
-import { parseYouTubeVideoId, buildYouTubeEmbedUrl } from './youtube'
+import { vi, afterEach } from 'vitest'
+import { parseYouTubeVideoId, buildYouTubeEmbedUrl, fetchYouTubeTitle } from './youtube'
 
 describe('parseYouTubeVideoId', () => {
   it('extracts id from youtube.com/watch?v=', () => {
@@ -64,5 +65,58 @@ describe('buildYouTubeEmbedUrl', () => {
     expect(url).toContain('playsinline=1')
     expect(url).toContain('rel=0')
     expect(url).toContain('modestbranding=1')
+  })
+})
+
+describe('fetchYouTubeTitle', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns the title from oEmbed response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ title: 'Never Gonna Give You Up' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const title = await fetchYouTubeTitle('dQw4w9WgXcQ')
+    expect(title).toBe('Never Gonna Give You Up')
+    const calledWith = fetchMock.mock.calls[0][0] as string
+    expect(calledWith).toContain('youtube.com/oembed')
+    expect(calledWith).toContain(encodeURIComponent('https://www.youtube.com/watch?v=dQw4w9WgXcQ'))
+  })
+
+  it('trims the returned title', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ title: '  Spaced Title  ' }),
+    }))
+    expect(await fetchYouTubeTitle('dQw4w9WgXcQ')).toBe('Spaced Title')
+  })
+
+  it('returns null on non-ok response (private/removed video)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) }))
+    expect(await fetchYouTubeTitle('dQw4w9WgXcQ')).toBeNull()
+  })
+
+  it('returns null on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+    expect(await fetchYouTubeTitle('dQw4w9WgXcQ')).toBeNull()
+  })
+
+  it('returns null when title is missing or empty', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ title: '   ' }),
+    }))
+    expect(await fetchYouTubeTitle('dQw4w9WgXcQ')).toBeNull()
+  })
+
+  it('returns null for an invalid video id without calling fetch', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    expect(await fetchYouTubeTitle('not-11-chars')).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -47,3 +47,23 @@ export function buildYouTubeEmbedUrl(videoId: string): string {
   }
   return `https://www.youtube.com/embed/${videoId}?${params.toString()}`
 }
+
+/**
+ * Fetch the video title via YouTube's public oEmbed endpoint. Returns null
+ * when the video is private/removed/age-gated, or when the network fails.
+ * The endpoint sets `Access-Control-Allow-Origin: *`, so this works from the
+ * browser without a proxy.
+ */
+export async function fetchYouTubeTitle(videoId: string, signal?: AbortSignal): Promise<string | null> {
+  if (!isValidVideoId(videoId)) return null
+  const target = `https://www.youtube.com/watch?v=${videoId}`
+  const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(target)}&format=json`
+  try {
+    const res = await fetch(oembedUrl, { signal })
+    if (!res.ok) return null
+    const data = await res.json() as { title?: unknown }
+    return typeof data.title === 'string' && data.title.trim() ? data.title.trim() : null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- Reference URL input becomes an MUI Autocomplete (freeSolo) with a dropdown of previously-loaded references
- Options show a human-readable primary label — YouTube video title (fetched via public oEmbed), Pexels photo.alt, or image filename — with the full URL as secondary text and a type icon (Film / Camera / Image)
- Per-entry trash icon deletes from history without re-triggering the reference load
- Persisted in a new Dexie v4 `urlHistory` store (50-entry cap, pruned oldest-first; existing PR-preview DB-name scoping isolates preview vs. main data)

## Test plan
- [x] `npm run lint`
- [x] `npm run test` — 186 passing (new coverage for `urlHistoryStore` + `fetchYouTubeTitle`)
- [x] `npm run build` — clean
- [x] Manual: paste YouTube URL → history entry appears with video title (~500ms)
- [x] Manual: paste Pexels photo URL → entry shows photo.alt
- [ ] Manual: paste image URL → entry shows filename
- [x] Manual: select from dropdown → reference reloads
- [x] Manual: trash icon → entry is removed and doesn't come back
- [ ] Manual: invalid URL → no history entry added
- [x] Manual: page reload → history persists
- [ ] Manual: iPad/touch — trash icon works without triggering selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)