### PR TITLE
fix: keep user zoom on iPad and clear guides without a reference

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -151,13 +151,10 @@ export function DrawingCanvas({
 
     rendererRef.current = new CanvasRenderer(ctx)
 
-    // Re-fit to reference size on resize, only when this panel owns the fit.
-    // When the reference panel is leading (shared-VT mode), it drives the fit and we just redraw.
-    if (fitSize && isFitLeader) {
-      fitToSize()
-    }
+    // Resize does not refit — that would clobber the user's manual zoom/pan.
+    // Fit happens only on fitSize change or viewResetVersion bump.
     redrawAll()
-  }, [redrawAll, fitSize, fitToSize, isFitLeader])
+  }, [redrawAll])
 
   // ResizeObserver
   useEffect(() => {
@@ -188,13 +185,16 @@ export function DrawingCanvas({
     }
   }, [viewResetVersion, redrawAll, fitSize, fitToSize])
 
-  // Re-fit when fitSize changes — only when this panel owns the fit.
+  // fitToSize/redrawAll omitted from deps on purpose: their identities churn
+  // on unrelated state (e.g. highlightedStrokeIndex), which would refit and
+  // clobber the user's manual zoom.
   useEffect(() => {
     if (fitSize && isFitLeader) {
       fitToSize()
       redrawAll()
     }
-  }, [fitSize, fitToSize, redrawAll, isFitLeader])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fitSize, isFitLeader])
 
   const getCanvasPoint = useCallback((clientX: number, clientY: number): Point => {
     const canvas = canvasRef.current!

--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -40,9 +40,14 @@ interface DrawingPanelProps {
   viewTransform?: ViewTransform
   /** Which panel owns the fit calculation. */
   fitLeader?: 'reference' | 'drawing'
+  /**
+   * Incremented by the parent to trigger an external view reset (e.g. on
+   * device orientation change). Bumps the internal viewResetVersion.
+   */
+  externalResetVersion?: number
 }
 
-export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerReady, onStrokesChanged, onOverlayClear, onLoadReference, onCurrentStrokeChange, captureReferenceSnapshot, timer, restoreVersion, historySyncVersion, isFlipped, viewTransform, fitLeader }: DrawingPanelProps) {
+export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerReady, onStrokesChanged, onOverlayClear, onLoadReference, onCurrentStrokeChange, captureReferenceSnapshot, timer, restoreVersion, historySyncVersion, isFlipped, viewTransform, fitLeader, externalResetVersion }: DrawingPanelProps) {
   const strokeManagerRef = useRef(new StrokeManager())
   const [mode, setMode] = useState<DrawingMode>('pen')
   const [highlightedStrokeIndex, setHighlightedStrokeIndex] = useState<number | null>(null)
@@ -80,6 +85,8 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
       setCanRedo(strokeManagerRef.current.canRedo())
     }
   }, [historySyncVersion])
+
+  const combinedResetVersion = viewResetVersion + (externalResetVersion ?? 0)
 
   const syncUndoRedoState = useCallback(() => {
     setCanUndo(strokeManagerRef.current.canUndo())
@@ -312,7 +319,7 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
           onStrokeCountChange={handleStrokeCountChange}
           strokeManagerRef={strokeManagerRef}
           redrawVersion={redrawVersion}
-          viewResetVersion={viewResetVersion}
+          viewResetVersion={combinedResetVersion}
           grid={grid}
           guideLines={lines}
           guideVersion={guideVersion}

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -166,8 +166,23 @@ export function ImageViewer({
     return viewTransform.subscribe(requestRedraw)
   }, [viewTransform, requestRedraw])
 
-  // Fit image to canvas on load. Canvas size is updated regardless of fit ownership;
-  // only the ViewTransform write is gated by isFitLeader.
+  // Buffer-only resize — leaves the ViewTransform alone so resize events don't
+  // clobber the user's manual zoom/pan.
+  const resizeCanvas = useCallback(() => {
+    const canvas = canvasRef.current
+    const container = containerRef.current
+    if (!canvas || !container) return
+
+    const dpr = window.devicePixelRatio || 1
+    const rect = container.getBoundingClientRect()
+    canvas.width = rect.width * dpr
+    canvas.height = rect.height * dpr
+    canvas.style.width = `${rect.width}px`
+    canvas.style.height = `${rect.height}px`
+
+    redraw()
+  }, [redraw])
+
   const fitImage = useCallback(() => {
     const canvas = canvasRef.current
     const container = containerRef.current
@@ -222,14 +237,13 @@ export function ImageViewer({
   // eslint-disable-next-line react-hooks/exhaustive-deps -- only reload when URL changes
   }, [imageUrl])
 
-  // ResizeObserver
   useEffect(() => {
     const container = containerRef.current
     if (!container) return
-    const observer = new ResizeObserver(() => fitImage())
+    const observer = new ResizeObserver(() => resizeCanvas())
     observer.observe(container)
     return () => observer.disconnect()
-  }, [fitImage])
+  }, [resizeCanvas])
 
   // Reset view
   useEffect(() => {

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -223,6 +223,11 @@ interface ReferencePanelProps {
   viewTransform?: ViewTransform
   /** Which panel owns the fit calculation. */
   fitLeader?: 'reference' | 'drawing'
+  /**
+   * Incremented by the parent to trigger an external view reset (e.g. on
+   * device orientation change). Bumps the internal viewResetVersion.
+   */
+  externalResetVersion?: number
 }
 
 export function ReferencePanel({
@@ -231,7 +236,7 @@ export function ReferencePanel({
   source, referenceMode, fixedImageUrl, localImageUrl, refInfo,
   onReferenceChange, onReferenceResetOnError,
   onRegisterLoadSketchfabModel, isFlipped, onToggleFlip,
-  viewTransform, fitLeader,
+  viewTransform, fitLeader, externalResetVersion,
 }: ReferencePanelProps) {
   const { grid, lines, version: guideVersion, cycleGridMode, addLine, removeLine, clearLines } = useGuides()
   const { isFullscreen, toggleFullscreen, isSupported: fullscreenSupported } = useFullscreen()
@@ -249,6 +254,8 @@ export function ReferencePanel({
   useEffect(() => {
     reloadUrlHistory()
   }, [reloadUrlHistory])
+
+  const combinedResetVersion = viewResetVersion + (externalResetVersion ?? 0)
 
   // Sketchfab viewer state (reported by child)
   const [sfShowViewer, setSfShowViewer] = useState(false)
@@ -563,7 +570,7 @@ export function ReferencePanel({
           </Button>
         )}
 
-        {/* Guide line tools (fixed images or YouTube) */}
+        {/* Guide line tools — add/delete-mode require a viewer to interact with. */}
         {(isFixed || isYouTube) && (
           <>
             <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
@@ -605,6 +612,19 @@ export function ReferencePanel({
                   <Trash2 size={20} />
                 </IconButton>
               </span>
+            </Tooltip>
+          </>
+        )}
+
+        {/* Clear-all works on guide state alone, so stay available even with no
+            reference loaded — otherwise stale guides become undeletable. */}
+        {!(isFixed || isYouTube) && lines.length > 0 && (
+          <>
+            <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
+            <Tooltip title={t('clearGuideLines')}>
+              <IconButton size="small" onClick={clearLines}>
+                <Trash2 size={20} />
+              </IconButton>
             </Tooltip>
           </>
         )}
@@ -880,7 +900,7 @@ export function ReferencePanel({
         {isFixed && displayImageUrl && (
           <ImageViewer
             imageUrl={displayImageUrl}
-            viewResetVersion={viewResetVersion}
+            viewResetVersion={combinedResetVersion}
             grid={grid}
             guideLines={lines}
             guideVersion={guideVersion}

--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -63,6 +63,17 @@ function SplitLayoutInner() {
   const [changeVersion, setChangeVersion] = useState(0)
   // Restore version to notify DrawingPanel after draft restore
   const [restoreVersion, setRestoreVersion] = useState(0)
+  // Explicit refit trigger on rotation — ResizeObservers don't auto-refit so
+  // user zoom survives incidental resizes, but rotation flips the layout hard
+  // enough that a refit is still wanted.
+  const [orientationResetVersion, setOrientationResetVersion] = useState(0)
+  const prevOrientationRef = useRef(orientation)
+  useEffect(() => {
+    if (prevOrientationRef.current !== orientation) {
+      prevOrientationRef.current = orientation
+      setOrientationResetVersion(v => v + 1)
+    }
+  }, [orientation])
   // History sync version: incremented when the StrokeManager's undo/redo
   // stacks change outside DrawingPanel (e.g. SplitLayout records a reference
   // change). DrawingPanel listens to this to refresh its canUndo/canRedo UI.
@@ -346,6 +357,7 @@ function SplitLayoutInner() {
           onToggleFlip={handleToggleFlip}
           viewTransform={viewTransformRef.current}
           fitLeader={fitLeader}
+          externalResetVersion={orientationResetVersion}
         />
       </Box>
       <Box sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
@@ -364,6 +376,7 @@ function SplitLayoutInner() {
           isFlipped={isFlipped}
           viewTransform={viewTransformRef.current}
           fitLeader={fitLeader}
+          externalResetVersion={orientationResetVersion}
         />
       </Box>
       </Box>

--- a/src/components/YouTubeViewer.tsx
+++ b/src/components/YouTubeViewer.tsx
@@ -209,18 +209,22 @@ export function YouTubeViewer({
     )
   }, [viewTransform, isFitLeader])
 
+  // Initial fit only — resize is handled by the placement-only observer below
+  // so the ViewTransform survives incidental resizes.
+  useEffect(() => {
+    writeFitToTransform()
+  }, [writeFitToTransform])
+
   useEffect(() => {
     const container = containerRef.current
     if (!container) return
     const observer = new ResizeObserver(() => {
-      writeFitToTransform()
       applyPlacement()
     })
     observer.observe(container)
-    writeFitToTransform()
     applyPlacement()
     return () => observer.disconnect()
-  }, [writeFitToTransform, applyPlacement])
+  }, [applyPlacement])
 
   // Subscribe to transform changes driven by the drawing canvas so the iframe
   // follows along when the user zooms/pans on the other panel.


### PR DESCRIPTION
## Summary

- iPadで描画するたびにズーム/パンが初期化されてしまう問題を修正。3つのビューア(`DrawingCanvas` / `ImageViewer` / `YouTubeViewer`)の`ResizeObserver`が`ViewTransform.fitTo()`を呼んでいたのが原因。iPad Safariのアドレスバー高さ変動や`useEffect`再アタッチによる`observe()`初回コールバックなど、些細なリサイズイベントでもユーザーの手動ズームが毎回破棄されていた。
- リサイズ時はキャンバスバッファ寸法のみ更新し、`ViewTransform`は維持するよう変更。fit-to-contentはお手本切り替え・明示リセット・端末回転の3契機に限定。
- `SplitLayout`に回転検知を追加し、landscape↔portrait 切り替え時は明示的にrefitをトリガーして従来挙動を保持。
- `DrawingCanvas`のfitSize useEffectから`fitToSize`/`redrawAll`を依存から外し、`highlightedStrokeIndex`などの無関係な状態変化でrefitが走らないようにした。
- お手本未ロード時でも補助線の「全消去」ボタンを表示し、古い補助線を単独で消せるようにした(個別削除モードはビューア上でのタップが必要なため従来どおりガード)。

## Test plan

- [x] `npm run lint`
- [x] `npm run test`(186 tests pass)
- [x] `npm run build`
- [x] iPad実機(PR preview): 画像 / YouTube のお手本をロード → ピンチで拡大 → Apple Pencilで描画してズームが維持されることを確認
- [ ] iPad実機: 消しゴム・Undo/Redoでもズーム維持
- [ ] iPad実機: ズームリセットボタンは従来通り動作
- [ ] iPad実機: 端末回転時に自動でfitが走る
- [x] デスクトップ: お手本を開いて補助線を数本追加 → お手本を閉じる → ツールバーにゴミ箱アイコンが出て全消去できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)