### PR TITLE
feat: expand URL history coverage and dedup YouTube by video ID (closes #83)

### DIFF
--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -217,6 +217,11 @@ interface ReferencePanelProps {
   /** Non-undoable reset used when an image fails to load. */
   onReferenceResetOnError: () => void
   onRegisterLoadSketchfabModel?: (fn: (uid: string) => void) => void
+  /**
+   * Allows the parent to trigger a refresh of the URL history dropdown after
+   * it adds an entry itself (e.g. Gallery "use this reference" reload).
+   */
+  onRegisterReloadUrlHistory?: (fn: () => void) => void
   isFlipped?: boolean
   onToggleFlip?: () => void
   /** Optional shared ViewTransform for zoom sync with DrawingPanel. */
@@ -235,7 +240,8 @@ export function ReferencePanel({
   onReferenceImageSize, overlayActive, onToggleOverlay,
   source, referenceMode, fixedImageUrl, localImageUrl, refInfo,
   onReferenceChange, onReferenceResetOnError,
-  onRegisterLoadSketchfabModel, isFlipped, onToggleFlip,
+  onRegisterLoadSketchfabModel, onRegisterReloadUrlHistory,
+  isFlipped, onToggleFlip,
   viewTransform, fitLeader, externalResetVersion,
 }: ReferencePanelProps) {
   const { grid, lines, version: guideVersion, cycleGridMode, addLine, removeLine, clearLines } = useGuides()
@@ -251,9 +257,17 @@ export function ReferencePanel({
     getUrlHistory().then(setUrlHistory).catch(() => { /* ignore storage errors */ })
   }, [])
 
+  const addAndReloadHistory = useCallback((url: string, type: UrlHistoryType, title?: string) => {
+    return addUrlHistory(url, type, title).then(reloadUrlHistory).catch(() => { /* ignore */ })
+  }, [reloadUrlHistory])
+
   useEffect(() => {
     reloadUrlHistory()
   }, [reloadUrlHistory])
+
+  useEffect(() => {
+    onRegisterReloadUrlHistory?.(reloadUrlHistory)
+  }, [onRegisterReloadUrlHistory, reloadUrlHistory])
 
   const combinedResetVersion = viewResetVersion + (externalResetVersion ?? 0)
 
@@ -328,8 +342,7 @@ export function ReferencePanel({
       setUrlLoading(false)
       fetchYouTubeTitle(ytId)
         .catch(() => null)
-        .then(title => addUrlHistory(url, 'youtube', title ?? undefined))
-        .then(reloadUrlHistory)
+        .then(title => addAndReloadHistory(url, 'youtube', title ?? undefined))
         .catch(() => { /* ignore */ })
       return
     }
@@ -348,7 +361,7 @@ export function ReferencePanel({
             s.setReferenceInfo(info)
           })
           setUrlInput('')
-          addUrlHistory(url, 'pexels', info.title).then(reloadUrlHistory).catch(() => { /* ignore */ })
+          void addAndReloadHistory(url, 'pexels', info.title)
         })
         .catch(e => setUrlError(t(mapPexelsErrorKey(e))))
         .finally(() => setUrlLoading(false))
@@ -372,7 +385,7 @@ export function ReferencePanel({
         s.setReferenceMode('fixed')
       })
       setUrlInput('')
-      addUrlHistory(url, 'url').then(reloadUrlHistory).catch(() => { /* ignore */ })
+      void addAndReloadHistory(url, 'url')
     }
 
     // Preload image: try CORS first, then without, check naturalWidth
@@ -390,7 +403,7 @@ export function ReferencePanel({
       retry.src = url
     }
     img.src = url
-  }, [onReferenceChange, reloadUrlHistory])
+  }, [onReferenceChange, addAndReloadHistory])
 
   const handleFixAngle = useCallback((screenshotUrl: string, info: ReferenceInfo) => {
     onReferenceChange(s => {
@@ -447,7 +460,10 @@ export function ReferencePanel({
       s.setLocalImageUrl(null)
       s.setReferenceInfo(info)
     })
-  }, [onReferenceChange])
+    if (info.pexelsPageUrl) {
+      void addAndReloadHistory(info.pexelsPageUrl, 'pexels', info.title)
+    }
+  }, [onReferenceChange, addAndReloadHistory])
 
   const handleBackToPexelsSearch = useCallback(() => {
     onReferenceChange(s => {

--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -12,6 +12,8 @@ import { StrokeManager } from '../drawing/StrokeManager'
 import { ViewTransform } from '../drawing/ViewTransform'
 import { loadDraft } from '../storage/sessionStore'
 import { cleanupStalePrDatabases } from '../storage/db'
+import { addUrlHistory } from '../storage/urlHistoryStore'
+import { buildYouTubeCanonicalUrl } from '../utils/youtube'
 import { t } from '../i18n'
 import type { Stroke, ReferenceSnapshot } from '../drawing/types'
 import type { ReferenceInfo, ReferenceSource, ReferenceMode } from '../types'
@@ -58,6 +60,9 @@ function SplitLayoutInner() {
 
   // Ref for loading Sketchfab model by UID (registered by ReferencePanel)
   const loadSketchfabModelFnRef = useRef<((uid: string) => void) | null>(null)
+  // Ref for refreshing the URL history dropdown after parent-initiated adds
+  // (e.g. Gallery "use this reference" reload).
+  const reloadUrlHistoryFnRef = useRef<(() => void) | null>(null)
 
   // Change version counter for autosave debouncing
   const [changeVersion, setChangeVersion] = useState(0)
@@ -201,8 +206,16 @@ function SplitLayoutInner() {
     loadSketchfabModelFnRef.current = fn
   }, [])
 
+  const handleRegisterReloadUrlHistory = useCallback((fn: () => void) => {
+    reloadUrlHistoryFnRef.current = fn
+  }, [])
+
   // Gallery "load reference" handler — routed through changeReference so the
-  // user can undo back to the previously-loaded reference.
+  // user can undo back to the previously-loaded reference. URL-representable
+  // sources (url / youtube / pexels) are also recorded into the URL history
+  // dropdown so reopening from the gallery surfaces them next to URL-pasted
+  // entries. Sketchfab (UID-based) and local-file images are not URL-
+  // representable, so they're skipped.
   const handleLoadReference = useCallback((info: ReferenceInfo) => {
     changeReference(s => {
       if (info.source === 'sketchfab' && info.sketchfabUid) {
@@ -232,6 +245,18 @@ function SplitLayoutInner() {
         s.setReferenceInfo(info)
       }
     })
+
+    let historyAdd: Promise<void> | null = null
+    if (info.source === 'url' && info.imageUrl) {
+      historyAdd = addUrlHistory(info.imageUrl, 'url', info.title)
+    } else if (info.source === 'youtube' && info.youtubeVideoId) {
+      historyAdd = addUrlHistory(buildYouTubeCanonicalUrl(info.youtubeVideoId), 'youtube', info.title)
+    } else if (info.source === 'pexels' && info.pexelsPageUrl) {
+      historyAdd = addUrlHistory(info.pexelsPageUrl, 'pexels', info.title)
+    }
+    if (historyAdd) {
+      historyAdd.then(() => reloadUrlHistoryFnRef.current?.()).catch(() => { /* ignore */ })
+    }
   }, [changeReference])
 
   // Autosave: read timer.elapsedMs via ref to avoid recreating this callback every frame
@@ -353,6 +378,7 @@ function SplitLayoutInner() {
           onReferenceChange={changeReference}
           onReferenceResetOnError={resetReferenceOnError}
           onRegisterLoadSketchfabModel={handleRegisterLoadSketchfabModel}
+          onRegisterReloadUrlHistory={handleRegisterReloadUrlHistory}
           isFlipped={isFlipped}
           onToggleFlip={handleToggleFlip}
           viewTransform={viewTransformRef.current}

--- a/src/storage/urlHistoryStore.test.ts
+++ b/src/storage/urlHistoryStore.test.ts
@@ -106,6 +106,44 @@ describe('urlHistoryStore', () => {
       expect(arg.title).toBeUndefined()
     })
 
+    it('canonicalizes YouTube URLs to https://youtu.be/<id> before storing', async () => {
+      await addUrlHistory('https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=30s', 'youtube')
+      const arg = mockPut().mock.calls[0][0] as UrlHistoryEntry
+      expect(arg.url).toBe('https://youtu.be/dQw4w9WgXcQ')
+    })
+
+    it('looks up existing YouTube entries by canonical key so titles survive across surface variants', async () => {
+      mockGet().mockResolvedValueOnce({
+        url: 'https://youtu.be/dQw4w9WgXcQ',
+        type: 'youtube',
+        title: 'Cached Title',
+        lastUsedAt: new Date(1000),
+      })
+      // Different surface form, same video — should hit the cached entry.
+      await addUrlHistory('https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'youtube')
+      expect(mockGet()).toHaveBeenCalledWith('https://youtu.be/dQw4w9WgXcQ')
+      const arg = mockPut().mock.calls[0][0] as UrlHistoryEntry
+      expect(arg.url).toBe('https://youtu.be/dQw4w9WgXcQ')
+      expect(arg.title).toBe('Cached Title')
+    })
+
+    it('does not canonicalize non-YouTube URLs', async () => {
+      await addUrlHistory('https://www.pexels.com/photo/whatever-12345/', 'pexels', 'shot')
+      await addUrlHistory('https://example.com/a.jpg?v=2', 'url')
+      const pexelsArg = mockPut().mock.calls[0][0] as UrlHistoryEntry
+      const urlArg = mockPut().mock.calls[1][0] as UrlHistoryEntry
+      expect(pexelsArg.url).toBe('https://www.pexels.com/photo/whatever-12345/')
+      expect(urlArg.url).toBe('https://example.com/a.jpg?v=2')
+    })
+
+    it('leaves a YouTube URL untouched when the video ID cannot be parsed', async () => {
+      // Not a valid YouTube watch URL — falls back to using the input as-is so
+      // the user still sees their entry rather than silently losing it.
+      await addUrlHistory('https://www.youtube.com/results?search_query=foo', 'youtube')
+      const arg = mockPut().mock.calls[0][0] as UrlHistoryEntry
+      expect(arg.url).toBe('https://www.youtube.com/results?search_query=foo')
+    })
+
     it('deletes the oldest entries when count exceeds the limit', async () => {
       const overLimit = URL_HISTORY_LIMIT + 3
       const entries: UrlHistoryEntry[] = Array.from({ length: overLimit }, (_, i) => ({

--- a/src/storage/urlHistoryStore.ts
+++ b/src/storage/urlHistoryStore.ts
@@ -1,6 +1,21 @@
 import { db, type UrlHistoryEntry, type UrlHistoryType } from './db'
+import { buildYouTubeCanonicalUrl, parseYouTubeVideoId } from '../utils/youtube'
 
 export const URL_HISTORY_LIMIT = 50
+
+/**
+ * Collapse surface variants of the same logical reference onto a single key so
+ * the history dedupes by identity, not by literal URL. Currently only YouTube
+ * needs this — `youtu.be/X`, `youtube.com/watch?v=X`, and the same URL with
+ * extra query params (e.g. `&t=30s`) all point to the same video.
+ */
+function canonicalizeUrl(url: string, type: UrlHistoryType): string {
+  if (type === 'youtube') {
+    const id = parseYouTubeVideoId(url)
+    if (id) return buildYouTubeCanonicalUrl(id)
+  }
+  return url
+}
 
 /**
  * Upsert a history entry. If `title` is omitted but an existing entry has one,
@@ -8,12 +23,13 @@ export const URL_HISTORY_LIMIT = 50
  * what we already knew.
  */
 export async function addUrlHistory(url: string, type: UrlHistoryType, title?: string): Promise<void> {
+  const key = canonicalizeUrl(url, type)
   let finalTitle = title?.trim() || undefined
   if (!finalTitle) {
-    const existing = await db.urlHistory.get(url)
+    const existing = await db.urlHistory.get(key)
     finalTitle = existing?.title
   }
-  const entry: UrlHistoryEntry = { url, type, lastUsedAt: new Date() }
+  const entry: UrlHistoryEntry = { url: key, type, lastUsedAt: new Date() }
   if (finalTitle) entry.title = finalTitle
   await db.urlHistory.put(entry)
   const all = await db.urlHistory.toArray()

--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -36,6 +36,15 @@ export function parseYouTubeVideoId(rawUrl: string): string | null {
   return null
 }
 
+/**
+ * Canonical watch-page URL used as the URL-history dedup key. All surface
+ * forms of the same video (`youtu.be/X`, `youtube.com/watch?v=X`, `...&t=30s`)
+ * collapse onto this single key.
+ */
+export function buildYouTubeCanonicalUrl(videoId: string): string {
+  return `https://youtu.be/${videoId}`
+}
+
 export function buildYouTubeEmbedUrl(videoId: string): string {
   const params = new URLSearchParams({
     playsinline: '1',


### PR DESCRIPTION
## Summary

Closes #83.

- Pexels 検索で選んだ写真も URL 履歴に追加されるようになった (これまでは URL 入力経由のみ)。
- ギャラリーの「このお手本を使う」での再読み込みも URL 履歴に追加 (URL / YouTube / Pexels)。Sketchfab (UID ベース) とローカルファイルは対象外。
- YouTube URL は動画 ID で重複排除。`youtu.be/X`, `youtube.com/watch?v=X`, `...&t=30s` などの surface 違いを `https://youtu.be/<id>` という canonical キーに正規化してから格納。`addUrlHistory` 内で正規化するため、呼び出し側は意識不要。
- `buildYouTubeCanonicalUrl` を `src/utils/youtube.ts` に切り出し、`ReferencePanel` 内の `addUrlHistory(...).then(reloadUrlHistory).catch(...)` の 4 箇所コピペを `addAndReloadHistory` ヘルパーに集約。

## Test plan

- [x] `npm run lint` — クリーン
- [x] `npm run test` — 190 passing (urlHistoryStore に正規化／タイトル保持／非 YouTube 透過／解析失敗フォールバックの 4 テスト追加)
- [x] `npm run build` — クリーン
- [ ] Manual: `https://www.youtube.com/watch?v=ID&t=30s` を貼って Enter → 履歴に 1 件。続いて `https://youtu.be/ID` を貼って Enter → 重複せず 1 件のまま、先頭に来ること
- [ ] Manual: Pexels 検索 → 写真選択 → URL 履歴ドロップダウンに新エントリが現れること
- [ ] Manual: ギャラリーから過去の YouTube/Pexels/URL 由来の絵を「このお手本を使う」 → 該当エントリが履歴先頭に来ること
- [ ] Manual: ギャラリーから Sketchfab / ローカル画像由来の絵を開いた場合は URL 履歴に追加されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)