### PR TITLE
fix: handle string type in Autocomplete isOptionEqualToValue for MUI v9

### DIFF
--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -763,7 +763,7 @@ export function ReferencePanel({
                 options={urlHistory}
                 filterOptions={x => x}
                 getOptionLabel={option => typeof option === 'string' ? option : option.url}
-                isOptionEqualToValue={(a, b) => a.url === b.url}
+                isOptionEqualToValue={(a, b) => typeof a !== 'string' && typeof b !== 'string' && a.url === b.url}
                 inputValue={urlInput}
                 onInputChange={(_, value, reason) => {
                   if (reason === 'input' || reason === 'clear') {


### PR DESCRIPTION
## Summary
- MUI v9 tightened `Autocomplete` typing: with `FreeSolo=true`, `isOptionEqualToValue` now receives `string | UrlHistoryEntry` for both arguments instead of just `UrlHistoryEntry`
- Production build on main started failing with `TS2339: Property 'url' does not exist on type 'string | UrlHistoryEntry'` after #69 merged
- Guard both sides with `typeof !== 'string'` before accessing `.url`

## Context
The MUI v9 upgrade PR #69 passed CI because the PR's CI job only ran `npm run build` without a clean tsc cache — after merge, the GitHub Pages deploy workflow ran from scratch and surfaced the type error. Locally reproduced and verified.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` clean
- [x] `npm run test` — 190 tests pass
- [ ] GitHub Pages deploy workflow succeeds on merge