### PR TITLE
test: cover undo/redo × timer interactions to cut manual QA

### DIFF
--- a/src/components/DrawingPanel.test.tsx
+++ b/src/components/DrawingPanel.test.tsx
@@ -1,0 +1,305 @@
+import { render, fireEvent, act } from '@testing-library/react'
+import { useEffect, useState, type ReactNode } from 'react'
+import { vi } from 'vitest'
+import { DrawingPanel } from './DrawingPanel'
+import { GuideProvider } from '../guides/GuideContext'
+import { useTimer, type TimerHandle } from '../hooks/useTimer'
+import { StrokeManager } from '../drawing/StrokeManager'
+import type { ReferenceSnapshot } from '../drawing/types'
+
+vi.mock('../storage', () => ({
+  saveDrawing: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../storage/generateThumbnail', () => ({
+  generateThumbnail: vi.fn().mockReturnValue('data:image/png;base64,zz'),
+}))
+vi.mock('./Gallery', () => ({
+  Gallery: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="gallery-stub">
+      <button onClick={onClose}>close gallery</button>
+    </div>
+  ),
+}))
+
+type StubCanvasProps = {
+  strokeManagerRef: React.RefObject<StrokeManager>
+  onStrokeCountChange: () => void
+}
+const canvasPropsRef: { current: StubCanvasProps | null } = { current: null }
+vi.mock('./DrawingCanvas', () => ({
+  DrawingCanvas: (props: StubCanvasProps) => {
+    canvasPropsRef.current = props
+    return <div data-testid="drawing-canvas-stub" />
+  },
+}))
+
+function snap(overrides: Partial<ReferenceSnapshot> = {}): ReferenceSnapshot {
+  return {
+    source: 'none',
+    referenceMode: 'browse',
+    fixedImageUrl: null,
+    localImageUrl: null,
+    referenceInfo: null,
+    ...overrides,
+  }
+}
+
+type Harness = {
+  timer: TimerHandle
+  sm: StrokeManager | null
+  bumpRestore: () => void
+  bumpHistory: () => void
+}
+
+function setup(opts: { captureRef?: () => ReferenceSnapshot } = {}) {
+  const harness: Harness = {
+    timer: null as unknown as TimerHandle,
+    sm: null,
+    bumpRestore: () => {},
+    bumpHistory: () => {},
+  }
+
+  function Inner({ children }: { children: (h: { timer: TimerHandle; restoreVersion: number; historySyncVersion: number }) => ReactNode }) {
+    const timer = useTimer()
+    const [restoreVersion, setRestoreVersion] = useState(0)
+    const [historySyncVersion, setHistorySyncVersion] = useState(0)
+
+    // Mirror handles into the external harness object via effects so the
+    // react-hooks/immutability lint rule is satisfied (mutating outside state
+    // during render is disallowed). Effects run after commit, and act() waits
+    // for them before returning, so the test always sees the latest values.
+    useEffect(() => {
+      harness.timer = timer
+    })
+    useEffect(() => {
+      harness.bumpRestore = () => setRestoreVersion(v => v + 1)
+      harness.bumpHistory = () => setHistorySyncVersion(v => v + 1)
+    }, [])
+
+    return <>{children({ timer, restoreVersion, historySyncVersion })}</>
+  }
+
+  const utils = render(
+    <GuideProvider>
+      <Inner>
+        {({ timer, restoreVersion, historySyncVersion }) => (
+          <DrawingPanel
+            timer={timer}
+            onStrokeManagerReady={sm => {
+              harness.sm = sm
+            }}
+            restoreVersion={restoreVersion}
+            historySyncVersion={historySyncVersion}
+            captureReferenceSnapshot={opts.captureRef}
+          />
+        )}
+      </Inner>
+    </GuideProvider>,
+  )
+
+  return { ...utils, harness }
+}
+
+function findIconButton(container: HTMLElement, iconClass: string): HTMLButtonElement {
+  const icon = container.querySelector(`svg.${iconClass}`)
+  if (!icon) throw new Error(`icon ${iconClass} not found`)
+  const button = icon.closest('button')
+  if (!button) throw new Error(`no button wraps ${iconClass}`)
+  return button as HTMLButtonElement
+}
+
+function addStroke(sm: StrokeManager, x: number, y: number) {
+  sm.startStroke({ x, y })
+  sm.appendStroke({ x: x + 10, y: y + 10 })
+  sm.endStroke()
+}
+
+describe('DrawingPanel undo/redo × timer integration', () => {
+  beforeEach(() => {
+    canvasPropsRef.current = null
+  })
+
+  it('resets timer when undo drains the history stack', () => {
+    const { container, harness } = setup()
+
+    // Draw one stroke; notify DrawingPanel via the canvas stub's callback so
+    // handleStrokeCountChange runs (syncs UI + auto-starts timer).
+    act(() => {
+      addStroke(harness.sm!, 0, 0)
+      canvasPropsRef.current!.onStrokeCountChange()
+    })
+
+    expect(harness.timer.isRunning).toBe(true)
+    const undoBtn = findIconButton(container, 'lucide-undo-2')
+    expect(undoBtn).not.toBeDisabled()
+
+    act(() => {
+      fireEvent.click(undoBtn)
+    })
+
+    expect(harness.sm!.canUndo()).toBe(false)
+    expect(harness.timer.isRunning).toBe(false)
+    expect(harness.timer.elapsedMs).toBe(0)
+  })
+
+  it('does not reset timer when undo only pops a reference entry (strokes remain)', () => {
+    const { container, harness } = setup({ captureRef: () => snap({ source: 'image' }) })
+
+    act(() => {
+      addStroke(harness.sm!, 0, 0)
+      canvasPropsRef.current!.onStrokeCountChange()
+      // Parent (SplitLayout) would call recordReferenceChange + bumpHistory for
+      // a reference edit. Simulate that here.
+      harness.sm!.recordReferenceChange(snap({ source: 'none' }))
+      harness.bumpHistory()
+    })
+
+    expect(harness.timer.isRunning).toBe(true)
+
+    // First undo pops the reference entry — stroke entry still on the stack.
+    const undoBtn = findIconButton(container, 'lucide-undo-2')
+    act(() => {
+      fireEvent.click(undoBtn)
+    })
+
+    expect(harness.sm!.canUndo()).toBe(true) // stroke entry remains
+    expect(harness.timer.isRunning).toBe(true)
+    expect(harness.timer.elapsedMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('auto-starts timer on redo when strokes are restored from an emptied stack', () => {
+    const { container, harness } = setup()
+
+    act(() => {
+      addStroke(harness.sm!, 0, 0)
+      canvasPropsRef.current!.onStrokeCountChange()
+    })
+    act(() => {
+      fireEvent.click(findIconButton(container, 'lucide-undo-2'))
+    })
+    expect(harness.timer.isRunning).toBe(false)
+    expect(harness.timer.elapsedMs).toBe(0)
+
+    const redoBtn = findIconButton(container, 'lucide-redo-2')
+    expect(redoBtn).not.toBeDisabled()
+
+    act(() => {
+      fireEvent.click(redoBtn)
+    })
+
+    expect(harness.sm!.getStrokes()).toHaveLength(1)
+    expect(harness.timer.isRunning).toBe(true)
+  })
+
+  it('does not touch the timer when eraser (deleteStroke) removes all strokes', () => {
+    const { harness } = setup()
+
+    act(() => {
+      addStroke(harness.sm!, 0, 0)
+      addStroke(harness.sm!, 100, 100)
+      canvasPropsRef.current!.onStrokeCountChange()
+    })
+
+    expect(harness.timer.isRunning).toBe(true)
+    const runningBeforeErase = harness.timer.isRunning
+
+    // Simulate eraser deleting both strokes via the manager directly.
+    act(() => {
+      harness.sm!.deleteStroke(0)
+      harness.sm!.deleteStroke(0)
+      // DrawingCanvas would normally call this after eraser deletes.
+      canvasPropsRef.current!.onStrokeCountChange()
+    })
+
+    expect(harness.sm!.getStrokes()).toHaveLength(0)
+    // Timer keeps running — eraser intentionally does not reset.
+    expect(harness.timer.isRunning).toBe(runningBeforeErase)
+  })
+})
+
+describe('DrawingPanel toolbar state', () => {
+  beforeEach(() => {
+    canvasPropsRef.current = null
+  })
+
+  it('disables the clear button when there are no strokes, enables it after drawing', () => {
+    const { container, harness } = setup()
+
+    const clearBtn = findIconButton(container, 'lucide-trash-2')
+    expect(clearBtn).toBeDisabled()
+
+    act(() => {
+      addStroke(harness.sm!, 0, 0)
+      canvasPropsRef.current!.onStrokeCountChange()
+    })
+
+    expect(clearBtn).not.toBeDisabled()
+  })
+
+  it('clear button resets the timer and clears the strokes', () => {
+    const { container, harness } = setup()
+
+    act(() => {
+      addStroke(harness.sm!, 0, 0)
+      canvasPropsRef.current!.onStrokeCountChange()
+    })
+    expect(harness.timer.isRunning).toBe(true)
+
+    const clearBtn = findIconButton(container, 'lucide-trash-2')
+    act(() => {
+      fireEvent.click(clearBtn)
+    })
+
+    expect(harness.sm!.getStrokes()).toHaveLength(0)
+    expect(harness.timer.isRunning).toBe(false)
+    expect(harness.timer.elapsedMs).toBe(0)
+  })
+})
+
+describe('DrawingPanel keyboard shortcuts × Gallery', () => {
+  beforeEach(() => {
+    canvasPropsRef.current = null
+  })
+
+  function fireKey(opts: KeyboardEventInit) {
+    const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...opts })
+    document.dispatchEvent(event)
+  }
+
+  it('suppresses Ctrl+Z undo while Gallery is open, and re-enables it on close', () => {
+    const { container, harness, getByTestId, queryByTestId } = setup()
+
+    // Arrange: one stroke on the manager, timer started via canvas callback.
+    act(() => {
+      addStroke(harness.sm!, 0, 0)
+      canvasPropsRef.current!.onStrokeCountChange()
+    })
+    expect(harness.sm!.getStrokes()).toHaveLength(1)
+
+    // Open Gallery (clicking the gallery IconButton also pauses the timer).
+    const galleryBtn = findIconButton(container, 'lucide-images')
+    act(() => {
+      fireEvent.click(galleryBtn)
+    })
+    expect(getByTestId('gallery-stub')).toBeInTheDocument()
+    expect(harness.timer.isRunning).toBe(false)
+
+    // Ctrl+Z should be ignored — stroke stays.
+    act(() => {
+      fireKey({ code: 'KeyZ', key: 'z', ctrlKey: true })
+    })
+    expect(harness.sm!.getStrokes()).toHaveLength(1)
+
+    // Close Gallery via the stub's button.
+    act(() => {
+      fireEvent.click(getByTestId('gallery-stub').querySelector('button')!)
+    })
+    expect(queryByTestId('gallery-stub')).not.toBeInTheDocument()
+
+    // Now Ctrl+Z should undo.
+    act(() => {
+      fireKey({ code: 'KeyZ', key: 'z', ctrlKey: true })
+    })
+    expect(harness.sm!.getStrokes()).toHaveLength(0)
+  })
+})

--- a/src/components/SplitLayout.test.tsx
+++ b/src/components/SplitLayout.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { vi } from 'vitest'
 import { SplitLayout } from './SplitLayout'
+import { loadDraft } from '../storage/sessionStore'
+import type { SessionDraft } from '../storage/db'
 
 vi.mock('../storage/sessionStore', () => ({
   saveDraft: vi.fn().mockResolvedValue(undefined),
@@ -271,4 +273,70 @@ describe('SplitLayout', () => {
       expect(screen.queryByLabelText('Show info')).not.toBeInTheDocument()
     })
   })
+
+  describe('draft restore', () => {
+    const loadDraftMock = vi.mocked(loadDraft)
+
+    afterEach(() => {
+      loadDraftMock.mockResolvedValue(undefined)
+    })
+
+    it('restores strokes, elapsed time, and URL reference from a saved draft', async () => {
+      const draft: SessionDraft = {
+        id: 1,
+        strokes: [
+          { points: [{ x: 0, y: 0 }, { x: 10, y: 10 }], timestamp: 1000 },
+          { points: [{ x: 20, y: 20 }, { x: 30, y: 30 }], timestamp: 2000 },
+        ],
+        redoStack: [],
+        elapsedMs: 90_000, // 1:30
+        source: 'url',
+        referenceInfo: {
+          source: 'url',
+          title: 'My saved reference',
+          author: '',
+          imageUrl: 'https://example.com/pic.jpg',
+        },
+        referenceImageData: null,
+        guideState: {
+          grid: { mode: 'normal' },
+          lines: [],
+        },
+        updatedAt: new Date(),
+      }
+      loadDraftMock.mockResolvedValueOnce(draft)
+
+      const { container } = render(<SplitLayout />)
+
+      // The timer shows the restored elapsed time.
+      await waitFor(() => {
+        expect(screen.getByText('1:30')).toBeInTheDocument()
+      })
+
+      // The undo button becomes enabled because the restored strokes populate
+      // the undo stack (via StrokeManager.loadState, which seeds `add` entries).
+      const undoIcon = container.querySelector('svg.lucide-undo-2')
+      const undoBtn = undoIcon!.closest('button') as HTMLButtonElement
+      expect(undoBtn).not.toBeDisabled()
+
+      // The source-selection UI should be gone since source is 'url', not 'none'.
+      expect(screen.queryByText('Image File')).not.toBeInTheDocument()
+    })
+
+    it('does nothing when no draft is stored', async () => {
+      loadDraftMock.mockResolvedValueOnce(undefined)
+
+      const { container } = render(<SplitLayout />)
+
+      // Source-selection UI is still visible, timer reads 0:00, undo disabled.
+      await waitFor(() => {
+        expect(screen.getByText('Image File')).toBeInTheDocument()
+      })
+      expect(screen.getByText('0:00')).toBeInTheDocument()
+      const undoIcon = container.querySelector('svg.lucide-undo-2')
+      const undoBtn = undoIcon!.closest('button') as HTMLButtonElement
+      expect(undoBtn).toBeDisabled()
+    })
+  })
+
 })

--- a/src/drawing/StrokeManager.test.ts
+++ b/src/drawing/StrokeManager.test.ts
@@ -635,6 +635,31 @@ describe('StrokeManager', () => {
       expect(restorer).not.toHaveBeenCalled()
     })
 
+    it('preserves stroke entries while pruning the oldest reference entry past the cap', () => {
+      // Interleave: stroke, then 21 reference changes. The first reference
+      // should be pruned, but the stroke must survive intact.
+      manager.setReferenceRestorer(vi.fn())
+      manager.startStroke({ x: 1, y: 1 })
+      manager.appendStroke({ x: 2, y: 2 })
+      manager.endStroke()
+
+      for (let i = 0; i < 21; i++) {
+        manager.recordReferenceChange(snap({ source: 'image', fixedImageUrl: `data:${i}` }))
+      }
+
+      // Undo everything and count kinds
+      let strokeKinds = 0
+      let refKinds = 0
+      while (manager.canUndo()) {
+        const r = manager.undo(() => snap({ source: 'image' }))
+        if (r?.kind === 'stroke') strokeKinds++
+        if (r?.kind === 'reference') refKinds++
+      }
+
+      expect(strokeKinds).toBe(1) // the stroke is kept
+      expect(refKinds).toBe(20) // cap enforced, 1 ref pruned
+    })
+
     it('keeps the reference count consistent when redo receives no captureCurrentRef', () => {
       manager.setReferenceRestorer(vi.fn())
       manager.recordReferenceChange(snap({ source: 'none' }))

--- a/src/hooks/useTimer.test.ts
+++ b/src/hooks/useTimer.test.ts
@@ -68,4 +68,132 @@ describe('useTimer', () => {
       expect(result.current.elapsedMs).toBeGreaterThanOrEqual(10000)
     })
   })
+
+  describe('reset + start', () => {
+    it('start() is idempotent while already running', () => {
+      const { result } = renderHook(() => useTimer())
+
+      act(() => {
+        result.current.start()
+      })
+      expect(result.current.isRunning).toBe(true)
+
+      // Calling start() again must be a no-op (no re-initialization of startTimeRef
+      // that would cause double-counting). Verify isRunning stays true and no error.
+      act(() => {
+        result.current.start()
+        result.current.start()
+      })
+      expect(result.current.isRunning).toBe(true)
+    })
+
+    it('start() after reset() resumes from 0', () => {
+      const { result } = renderHook(() => useTimer())
+
+      act(() => {
+        result.current.restore(45000)
+      })
+      expect(result.current.elapsedMs).toBe(45000)
+
+      act(() => {
+        result.current.reset()
+      })
+      expect(result.current.elapsedMs).toBe(0)
+      expect(result.current.isRunning).toBe(false)
+
+      act(() => {
+        result.current.start()
+      })
+      expect(result.current.isRunning).toBe(true)
+      // Still near 0 immediately after start (no accumulated time from the pre-reset state).
+      expect(result.current.elapsedMs).toBeLessThan(100)
+    })
+
+    it('pause() + start() accumulates without double-counting', () => {
+      const { result } = renderHook(() => useTimer())
+
+      // Seed a known accumulated value using restore, then start.
+      act(() => {
+        result.current.restore(3000)
+        result.current.start()
+      })
+
+      // Pause — accumulated should be >= 3000 but not wildly larger.
+      act(() => {
+        result.current.pause()
+      })
+      expect(result.current.isRunning).toBe(false)
+      const afterPause = result.current.elapsedMs
+      expect(afterPause).toBeGreaterThanOrEqual(3000)
+
+      // Restart; elapsedMs should stay >= afterPause (never rewinds below it).
+      act(() => {
+        result.current.start()
+      })
+      expect(result.current.elapsedMs).toBeGreaterThanOrEqual(afterPause)
+    })
+  })
+
+  describe('visibility change', () => {
+    const originalHidden = Object.getOwnPropertyDescriptor(Document.prototype, 'hidden')
+
+    afterEach(() => {
+      if (originalHidden) {
+        Object.defineProperty(Document.prototype, 'hidden', originalHidden)
+      }
+    })
+
+    function setHidden(hidden: boolean) {
+      Object.defineProperty(document, 'hidden', {
+        configurable: true,
+        get: () => hidden,
+      })
+      document.dispatchEvent(new Event('visibilitychange'))
+    }
+
+    it('pauses the animation loop while the document is hidden, and resumes on visible', () => {
+      const { result } = renderHook(() => useTimer())
+
+      act(() => {
+        result.current.start()
+      })
+      expect(result.current.isRunning).toBe(true)
+
+      // Hide the tab — the hook should stop the rAF loop. isRunning is left unchanged
+      // (the hook keeps the flag so it knows to auto-resume on visible).
+      act(() => {
+        setHidden(true)
+      })
+      expect(result.current.isRunning).toBe(true)
+
+      // Show the tab again — rAF loop restarts, no state corruption.
+      act(() => {
+        setHidden(false)
+      })
+      expect(result.current.isRunning).toBe(true)
+    })
+  })
+
+  describe('reset behavior', () => {
+    it('reset() zeroes elapsed and stops the timer even if never started', () => {
+      const { result } = renderHook(() => useTimer())
+      act(() => {
+        result.current.reset()
+      })
+      expect(result.current.elapsedMs).toBe(0)
+      expect(result.current.isRunning).toBe(false)
+    })
+
+    it('reset() while running stops the timer and zeroes elapsed', () => {
+      const { result } = renderHook(() => useTimer())
+      act(() => {
+        result.current.start()
+      })
+      act(() => {
+        result.current.reset()
+      })
+      expect(result.current.elapsedMs).toBe(0)
+      expect(result.current.isRunning).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- PR ごとに手動で繰り返していた「線を描く → undo 連打 → タイマーがリセットされるか」「redo で戻したら動き出すか」「reference 変更後の undo でタイマーが pause のままか」などの複合挙動を自動テスト化。
- `DrawingPanel.test.tsx` を新設（undo/redo/clear × timer × strokeManager の連携、Gallery open 中の Ctrl+Z 抑止）。
- `useTimer` に境界ケース (reset→start / pause→start 累積 / start 冪等性 / visibility change) を追加。
- `StrokeManager` の「stroke を含む interleaved prune」ケース (MAX_REFERENCE_HISTORY 越え) を追加。
- `SplitLayout` に draft restore のシナリオテスト (strokes + elapsed + URL reference の復元) を追加。
- プロダクションコードは未変更。テストのみの追加。

Test suite: **190 → 206 tests** (+16), **12 → 13 files**.

## Verification

- [x] `npm run lint` クリーン
- [x] `npm run build` 成功
- [x] `npm test -- --run` 206 件すべて pass
- [x] ミューテーションテスト: `DrawingPanel.tsx` の `handleUndo` で `canUndo` ガードを無効化 → 対応する 2 件が fail することを確認 (回帰検知として機能)

## Non-goals

- Canvas のピクセル視覚回帰、SketchfabViewer / YouTubeViewer の iframe 側、タッチジェスチャ認識、E2E は今回対象外 (ROI とモックコスト観点)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)