### PR TITLE
feat: emphasize timer color to clarify running/paused state

### DIFF
--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -269,7 +269,7 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
           sx={{
             fontFamily: 'monospace',
             fontSize: '0.9rem',
-            color: timer.isRunning ? 'text.primary' : 'text.secondary',
+            color: timer.isRunning ? 'primary.main' : 'text.disabled',
             minWidth: 48,
             textAlign: 'right',
           }}

--- a/src/hooks/useTimer.test.ts
+++ b/src/hooks/useTimer.test.ts
@@ -159,18 +159,40 @@ describe('useTimer', () => {
       })
       expect(result.current.isRunning).toBe(true)
 
-      // Hide the tab — the hook should stop the rAF loop. isRunning is left unchanged
-      // (the hook keeps the flag so it knows to auto-resume on visible).
+      // Hide the tab — the hook stops the rAF loop AND flips isRunning off so
+      // the UI reflects the paused state (color change, etc).
       act(() => {
         setHidden(true)
       })
-      expect(result.current.isRunning).toBe(true)
+      expect(result.current.isRunning).toBe(false)
 
-      // Show the tab again — rAF loop restarts, no state corruption.
+      // Show the tab again — rAF loop restarts and isRunning goes back to true.
       act(() => {
         setHidden(false)
       })
       expect(result.current.isRunning).toBe(true)
+    })
+
+    it('does not auto-resume on visible if the timer was paused before hiding', () => {
+      const { result } = renderHook(() => useTimer())
+
+      act(() => {
+        result.current.start()
+      })
+      act(() => {
+        result.current.pause()
+      })
+      expect(result.current.isRunning).toBe(false)
+
+      act(() => {
+        setHidden(true)
+      })
+      expect(result.current.isRunning).toBe(false)
+
+      act(() => {
+        setHidden(false)
+      })
+      expect(result.current.isRunning).toBe(false)
     })
   })
 

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -7,6 +7,9 @@ export function useTimer() {
   const accumulatedRef = useRef(0)
   const rafIdRef = useRef<number>(0)
   const tickRef = useRef<() => void>(() => {})
+  // Tracks the "should be running" intent so visible-resume can restart even
+  // though we flip isRunning off on hidden to keep the UI in sync.
+  const shouldRunRef = useRef(false)
 
   // Update tick function
   useEffect(() => {
@@ -20,6 +23,7 @@ export function useTimer() {
 
   const start = useCallback(() => {
     if (startTimeRef.current !== null) return
+    shouldRunRef.current = true
     startTimeRef.current = Date.now()
     setIsRunning(true)
     rafIdRef.current = requestAnimationFrame(tickRef.current)
@@ -27,6 +31,7 @@ export function useTimer() {
 
   const pause = useCallback(() => {
     if (startTimeRef.current === null) return
+    shouldRunRef.current = false
     accumulatedRef.current += Date.now() - startTimeRef.current
     startTimeRef.current = null
     setIsRunning(false)
@@ -35,6 +40,7 @@ export function useTimer() {
   }, [])
 
   const reset = useCallback(() => {
+    shouldRunRef.current = false
     cancelAnimationFrame(rafIdRef.current)
     startTimeRef.current = null
     accumulatedRef.current = 0
@@ -50,17 +56,19 @@ export function useTimer() {
           accumulatedRef.current += Date.now() - startTimeRef.current
           startTimeRef.current = null
           cancelAnimationFrame(rafIdRef.current)
+          setIsRunning(false)
         }
       } else {
-        if (isRunning && startTimeRef.current === null) {
+        if (shouldRunRef.current && startTimeRef.current === null) {
           startTimeRef.current = Date.now()
+          setIsRunning(true)
           rafIdRef.current = requestAnimationFrame(tickRef.current)
         }
       }
     }
     document.addEventListener('visibilitychange', handleVisibility)
     return () => document.removeEventListener('visibilitychange', handleVisibility)
-  }, [isRunning])
+  }, [])
 
   // Cleanup on unmount
   useEffect(() => {
@@ -68,6 +76,7 @@ export function useTimer() {
   }, [])
 
   const restore = useCallback((ms: number) => {
+    shouldRunRef.current = false
     cancelAnimationFrame(rafIdRef.current)
     startTimeRef.current = null
     accumulatedRef.current = ms


### PR DESCRIPTION
## Summary
- タイマー表示の「動作中 / 一時停止中」の区別を一目でわかるように、色分岐を `text.primary` / `text.secondary` (差が微妙) から `primary.main` / `text.disabled` (青アクセント vs. 明確に薄いグレー) に変更
- 既存のレイアウト・フォント・幅は据え置きで、色指定1行のみの変更
- あわせて `useTimer` の visibilitychange ハンドラのバグを修正: hidden 時に `setIsRunning(false)` を呼んでおらず色が変わらなかった問題を、再開意図を別 ref (`shouldRunRef`) に分離して解消。pause 済みのタイマーはタブ復帰で再開しない挙動も維持
- 既存テストの期待値を更新 (hidden 中は `isRunning=false`) し、「pause 済みなら visible 復帰で再開しない」ケースを追加

## Test plan
- [x] `npm run lint` パス
- [x] `npm run build` パス (TypeScript 型チェック込み)
- [x] `npm run test` 207件パス (useTimer: 14件)
- [x] 動作確認: ストローク開始でタイマーが青色点灯、保存 / Gallery 開閉 / タブ非アクティブで薄いグレーに戻ることをブラウザで確認
- [x] 動作確認: Undo で履歴が空になったときにリセット・薄いグレー表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)