### PR TITLE
fix: enable iPad pinch-zoom on reference ImageViewer

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -67,6 +67,9 @@ export function DrawingCanvas({
   // Pinch state
   const pinchRef = useRef<{ id1: number; id2: number; lastDist: number; lastMidX: number; lastMidY: number } | null>(null)
   const activeTouchesRef = useRef<Map<number, { x: number; y: number }>>(new Map())
+  // Cached canvas rect captured at pinch start; reused each touchmove to avoid
+  // forcing a synchronous layout at 60fps.
+  const pinchRectRef = useRef<DOMRect | null>(null)
 
   const notifyStrokeCount = useCallback(() => {
     onStrokeCountChange()
@@ -286,6 +289,7 @@ export function DrawingCanvas({
         lastMidX: (t1.x + t2.x) / 2,
         lastMidY: (t1.y + t2.y) / 2,
       }
+      pinchRectRef.current = canvasRef.current!.getBoundingClientRect()
       return
     }
 
@@ -329,8 +333,7 @@ export function DrawingCanvas({
       const midX = (t1.x + t2.x) / 2
       const midY = (t1.y + t2.y) / 2
 
-      const canvas = canvasRef.current!
-      const rect = canvas.getBoundingClientRect()
+      const rect = pinchRectRef.current!
       let focalX = midX - rect.left
       const focalY = midY - rect.top
       if (isFlipped) {
@@ -376,6 +379,7 @@ export function DrawingCanvas({
       if (!activeTouchesRef.current.has(pinchRef.current.id1) ||
           !activeTouchesRef.current.has(pinchRef.current.id2)) {
         pinchRef.current = null
+        pinchRectRef.current = null
       }
     }
 

--- a/src/components/ImageViewer.test.tsx
+++ b/src/components/ImageViewer.test.tsx
@@ -1,0 +1,159 @@
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ImageViewer } from './ImageViewer'
+import { ViewTransform } from '../drawing/ViewTransform'
+import type { GridSettings } from '../guides/types'
+
+const grid: GridSettings = { mode: 'none' }
+
+const baseProps = {
+  imageUrl: 'https://example.com/test.png',
+  viewResetVersion: 0,
+  grid,
+  guideLines: [] as const,
+  guideVersion: 0,
+}
+
+function touch(identifier: number, clientX: number, clientY: number): Touch {
+  return { identifier, clientX, clientY } as Touch
+}
+
+const CANVAS_RECT: DOMRect = {
+  left: 10,
+  top: 20,
+  right: 410,
+  bottom: 320,
+  width: 400,
+  height: 300,
+  x: 10,
+  y: 20,
+  toJSON: () => ({}),
+}
+
+beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(CANVAS_RECT)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('ImageViewer pinch gesture', () => {
+  it('does not call applyPinch on 2-finger touchStart alone (only on move)', () => {
+    const applyPinch = vi.spyOn(ViewTransform.prototype, 'applyPinch')
+    const { container } = render(<ImageViewer {...baseProps} guideMode="none" />)
+    const canvas = container.querySelector('canvas')!
+
+    fireEvent.touchStart(canvas, { changedTouches: [touch(0, 100, 100), touch(1, 200, 200)] })
+
+    expect(applyPinch).not.toHaveBeenCalled()
+  })
+
+  it('calls applyPinch on 2-finger touchMove', () => {
+    const applyPinch = vi.spyOn(ViewTransform.prototype, 'applyPinch')
+    const { container } = render(<ImageViewer {...baseProps} guideMode="none" />)
+    const canvas = container.querySelector('canvas')!
+
+    fireEvent.touchStart(canvas, { changedTouches: [touch(0, 100, 100), touch(1, 200, 200)] })
+    fireEvent.touchMove(canvas, { changedTouches: [touch(0, 80, 80), touch(1, 220, 220)] })
+
+    expect(applyPinch).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call applyPinch on single-finger touchMove', () => {
+    const applyPinch = vi.spyOn(ViewTransform.prototype, 'applyPinch')
+    const { container } = render(<ImageViewer {...baseProps} guideMode="none" />)
+    const canvas = container.querySelector('canvas')!
+
+    fireEvent.touchStart(canvas, { changedTouches: [touch(0, 100, 100)] })
+    fireEvent.touchMove(canvas, { changedTouches: [touch(0, 150, 150)] })
+
+    expect(applyPinch).not.toHaveBeenCalled()
+  })
+
+  it('discards in-progress guide drawing when a 2nd finger touches during guideMode=add', () => {
+    const onAddGuideLine = vi.fn()
+    const { container } = render(
+      <ImageViewer {...baseProps} guideMode="add" onAddGuideLine={onAddGuideLine} />,
+    )
+    const canvas = container.querySelector('canvas')!
+
+    fireEvent.touchStart(canvas, { changedTouches: [touch(0, 100, 100)] })
+    fireEvent.touchMove(canvas, { changedTouches: [touch(0, 200, 200)] })
+    fireEvent.touchStart(canvas, { changedTouches: [touch(1, 300, 300)] })
+    fireEvent.touchEnd(canvas, { changedTouches: [touch(0, 200, 200), touch(1, 300, 300)] })
+
+    expect(onAddGuideLine).not.toHaveBeenCalled()
+  })
+
+  it('stops pinching and ignores remaining finger when one lifts', () => {
+    const applyPinch = vi.spyOn(ViewTransform.prototype, 'applyPinch')
+    const { container } = render(<ImageViewer {...baseProps} guideMode="none" />)
+    const canvas = container.querySelector('canvas')!
+
+    fireEvent.touchStart(canvas, { changedTouches: [touch(0, 100, 100), touch(1, 200, 200)] })
+    fireEvent.touchMove(canvas, { changedTouches: [touch(0, 80, 80), touch(1, 220, 220)] })
+    expect(applyPinch).toHaveBeenCalledTimes(1)
+
+    fireEvent.touchEnd(canvas, { changedTouches: [touch(1, 220, 220)] })
+    applyPinch.mockClear()
+
+    fireEvent.touchMove(canvas, { changedTouches: [touch(0, 50, 50)] })
+    expect(applyPinch).not.toHaveBeenCalled()
+  })
+
+  it('captures canvas rect once at pinch start and reuses it during touchMove', () => {
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue(CANVAS_RECT)
+    const { container } = render(<ImageViewer {...baseProps} guideMode="none" />)
+    const canvas = container.querySelector('canvas')!
+
+    rectSpy.mockClear()
+
+    fireEvent.touchStart(canvas, { changedTouches: [touch(0, 100, 100), touch(1, 200, 200)] })
+    const countAfterStart = rectSpy.mock.calls.length
+    expect(countAfterStart).toBeGreaterThanOrEqual(1)
+
+    fireEvent.touchMove(canvas, { changedTouches: [touch(0, 90, 90), touch(1, 210, 210)] })
+    fireEvent.touchMove(canvas, { changedTouches: [touch(0, 80, 80), touch(1, 220, 220)] })
+    fireEvent.touchMove(canvas, { changedTouches: [touch(0, 70, 70), touch(1, 230, 230)] })
+
+    expect(rectSpy.mock.calls.length).toBe(countAfterStart)
+  })
+
+  it('flips focalX and translateX when isFlipped=true', () => {
+    const applyPinch = vi.spyOn(ViewTransform.prototype, 'applyPinch')
+    const { container } = render(
+      <ImageViewer {...baseProps} guideMode="none" isFlipped />,
+    )
+    const canvas = container.querySelector('canvas')!
+
+    // pinch starts with midpoint (100, 100); rect.left=10 rect.top=20 rect.width=400
+    fireEvent.touchStart(canvas, { changedTouches: [touch(0, 50, 50), touch(1, 150, 150)] })
+    // expand — midpoint unchanged (still 100, 100), translate should be 0
+    fireEvent.touchMove(canvas, { changedTouches: [touch(0, 30, 30), touch(1, 170, 170)] })
+
+    expect(applyPinch).toHaveBeenCalledTimes(1)
+    const [focalX, focalY, scaleDelta, translateX, translateY] = applyPinch.mock.calls[0]
+    // raw focalX = 100 - 10 = 90 → flipped = 400 - 90 = 310
+    expect(focalX).toBeCloseTo(310)
+    expect(focalY).toBeCloseTo(80)
+    expect(scaleDelta).toBeGreaterThan(1)
+    expect(translateX).toBe(-0)
+    expect(translateY).toBe(0)
+  })
+
+  it('passes non-flipped focalX when isFlipped=false', () => {
+    const applyPinch = vi.spyOn(ViewTransform.prototype, 'applyPinch')
+    const { container } = render(<ImageViewer {...baseProps} guideMode="none" />)
+    const canvas = container.querySelector('canvas')!
+
+    fireEvent.touchStart(canvas, { changedTouches: [touch(0, 50, 50), touch(1, 150, 150)] })
+    fireEvent.touchMove(canvas, { changedTouches: [touch(0, 30, 30), touch(1, 170, 170)] })
+
+    const [focalX, focalY] = applyPinch.mock.calls[0]
+    expect(focalX).toBeCloseTo(90)
+    expect(focalY).toBeCloseTo(80)
+  })
+})

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -71,6 +71,16 @@ export function ImageViewer({
   const [dragStart, setDragStart] = useState<Point | null>(null)
   const [dragEnd, setDragEnd] = useState<Point | null>(null)
 
+  // Pinch state for 2-finger touch zoom/pan
+  const pinchRef = useRef<{
+    id1: number
+    id2: number
+    lastDist: number
+    lastMidX: number
+    lastMidY: number
+  } | null>(null)
+  const activeTouchesRef = useRef<Map<number, { x: number; y: number }>>(new Map())
+
   const getCanvasPoint = useCallback((clientX: number, clientY: number): Point => {
     const canvas = canvasRef.current!
     const rect = canvas.getBoundingClientRect()
@@ -330,8 +340,34 @@ export function ImageViewer({
     setDragEnd(null)
   }, [guideMode, dragStart, dragEnd, onAddGuideLine])
 
-  // Touch handlers for guide line interaction
+  // Touch handlers: 2-finger pinch zoom/pan takes precedence over guide interaction
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    for (let i = 0; i < e.changedTouches.length; i++) {
+      const touch = e.changedTouches[i]
+      activeTouchesRef.current.set(touch.identifier, { x: touch.clientX, y: touch.clientY })
+    }
+
+    if (activeTouchesRef.current.size >= 2) {
+      e.preventDefault()
+      if (dragStart || dragEnd) {
+        setDragStart(null)
+        setDragEnd(null)
+      }
+      const ids = Array.from(activeTouchesRef.current.keys())
+      const t1 = activeTouchesRef.current.get(ids[0])!
+      const t2 = activeTouchesRef.current.get(ids[1])!
+      const dx = t2.x - t1.x
+      const dy = t2.y - t1.y
+      pinchRef.current = {
+        id1: ids[0],
+        id2: ids[1],
+        lastDist: Math.sqrt(dx * dx + dy * dy),
+        lastMidX: (t1.x + t2.x) / 2,
+        lastMidY: (t1.y + t2.y) / 2,
+      }
+      return
+    }
+
     if (guideMode === 'none') return
     e.preventDefault()
     const touch = e.changedTouches[0]
@@ -353,17 +389,70 @@ export function ImageViewer({
       }
       onHighlightGuide?.(best?.id ?? null)
     }
-  }, [guideMode, getCanvasPoint, guideLines, onHighlightGuide])
+  }, [guideMode, getCanvasPoint, guideLines, onHighlightGuide, dragStart, dragEnd])
 
   const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    for (let i = 0; i < e.changedTouches.length; i++) {
+      const touch = e.changedTouches[i]
+      activeTouchesRef.current.set(touch.identifier, { x: touch.clientX, y: touch.clientY })
+    }
+
+    if (pinchRef.current) {
+      const t1 = activeTouchesRef.current.get(pinchRef.current.id1)
+      const t2 = activeTouchesRef.current.get(pinchRef.current.id2)
+      if (!t1 || !t2) return
+      e.preventDefault()
+
+      const dx = t2.x - t1.x
+      const dy = t2.y - t1.y
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      const midX = (t1.x + t2.x) / 2
+      const midY = (t1.y + t2.y) / 2
+
+      const canvas = canvasRef.current!
+      const rect = canvas.getBoundingClientRect()
+      let focalX = midX - rect.left
+      const focalY = midY - rect.top
+      if (isFlipped) {
+        focalX = rect.width - focalX
+      }
+
+      const scaleDelta = dist / pinchRef.current.lastDist
+      const rawTranslateX = midX - pinchRef.current.lastMidX
+      const translateX = isFlipped ? -rawTranslateX : rawTranslateX
+      const translateY = midY - pinchRef.current.lastMidY
+
+      viewTransformRef.current.applyPinch(focalX, focalY, scaleDelta, translateX, translateY)
+
+      pinchRef.current.lastDist = dist
+      pinchRef.current.lastMidX = midX
+      pinchRef.current.lastMidY = midY
+
+      requestRedraw()
+      return
+    }
+
     if (guideMode !== 'add' || !dragStart) return
     e.preventDefault()
     const touch = e.changedTouches[0]
     setDragEnd(getCanvasPoint(touch.clientX, touch.clientY))
     requestRedraw()
-  }, [guideMode, dragStart, getCanvasPoint, requestRedraw])
+  }, [guideMode, dragStart, getCanvasPoint, requestRedraw, isFlipped])
 
   const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    for (let i = 0; i < e.changedTouches.length; i++) {
+      activeTouchesRef.current.delete(e.changedTouches[i].identifier)
+    }
+
+    if (pinchRef.current) {
+      if (!activeTouchesRef.current.has(pinchRef.current.id1) ||
+          !activeTouchesRef.current.has(pinchRef.current.id2)) {
+        pinchRef.current = null
+      }
+      e.preventDefault()
+      return
+    }
+
     if (guideMode !== 'add' || !dragStart || !dragEnd) return
     e.preventDefault()
     const dx = dragEnd.x - dragStart.x
@@ -393,7 +482,7 @@ export function ImageViewer({
           display: 'block',
           width: '100%',
           height: '100%',
-          touchAction: guideMode !== 'none' ? 'none' : 'auto',
+          touchAction: 'none',
           cursor,
         }}
       />

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -71,7 +71,6 @@ export function ImageViewer({
   const [dragStart, setDragStart] = useState<Point | null>(null)
   const [dragEnd, setDragEnd] = useState<Point | null>(null)
 
-  // Pinch state for 2-finger touch zoom/pan
   const pinchRef = useRef<{
     id1: number
     id2: number
@@ -80,6 +79,9 @@ export function ImageViewer({
     lastMidY: number
   } | null>(null)
   const activeTouchesRef = useRef<Map<number, { x: number; y: number }>>(new Map())
+  // Cached canvas rect captured at pinch start; reused each touchmove to avoid
+  // forcing a synchronous layout at 60fps.
+  const pinchRectRef = useRef<DOMRect | null>(null)
 
   const getCanvasPoint = useCallback((clientX: number, clientY: number): Point => {
     const canvas = canvasRef.current!
@@ -340,7 +342,6 @@ export function ImageViewer({
     setDragEnd(null)
   }, [guideMode, dragStart, dragEnd, onAddGuideLine])
 
-  // Touch handlers: 2-finger pinch zoom/pan takes precedence over guide interaction
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
     for (let i = 0; i < e.changedTouches.length; i++) {
       const touch = e.changedTouches[i]
@@ -365,6 +366,7 @@ export function ImageViewer({
         lastMidX: (t1.x + t2.x) / 2,
         lastMidY: (t1.y + t2.y) / 2,
       }
+      pinchRectRef.current = canvasRef.current!.getBoundingClientRect()
       return
     }
 
@@ -409,8 +411,7 @@ export function ImageViewer({
       const midX = (t1.x + t2.x) / 2
       const midY = (t1.y + t2.y) / 2
 
-      const canvas = canvasRef.current!
-      const rect = canvas.getBoundingClientRect()
+      const rect = pinchRectRef.current!
       let focalX = midX - rect.left
       const focalY = midY - rect.top
       if (isFlipped) {
@@ -448,6 +449,7 @@ export function ImageViewer({
       if (!activeTouchesRef.current.has(pinchRef.current.id1) ||
           !activeTouchesRef.current.has(pinchRef.current.id2)) {
         pinchRef.current = null
+        pinchRectRef.current = null
       }
       e.preventDefault()
       return


### PR DESCRIPTION
## Summary

- 手本側 (`ImageViewer`) で iPad の 2 本指ピンチズームが効かなかった不具合を修正。DrawingCanvas と同じ `activeTouchesRef` + `pinchRef` パターンを移植し、既存のガイドライン用 touch ハンドラと統合。
- `touchAction` を常に `'none'` に変更(旧: guideMode 非使用時は `'auto'`)。`'auto'` だと iOS Safari がピンチをページズームに吸ってしまい、`touchstart` が届かなかった。
- 指の本数を優先基準にし、2 本以上 → ピンチ/パン(ガイドモード中でも優先)、1 本 → 既存のガイド操作。ガイド描画中に 2 本目が触れたら `dragStart`/`dragEnd` を破棄してピンチに切替。
- `isFlipped` 時は focalX / translateX を反転(DrawingCanvas と同じ)。
- 影響範囲: Pexels 写真・SketchFab の Fix This Angle 後・URL 画像・ローカル画像(すべて ImageViewer 経由)。YouTubeViewer は iframe 経由のため本 PR のスコープ外。

## Follow-ups in this PR

- **perf**: `getBoundingClientRect()` を pinch 開始時にキャッシュし、touchmove 中の強制 reflow を回避(ImageViewer / DrawingCanvas 両方に対称適用)。
- **test**: ImageViewer のピンチ分岐ロジックに単体テストを追加(8 ケース、iPad を要するチェック項目を自動化)。

## Test plan

- [x] `npm run lint`
- [x] `npm run build` (型チェック含む)
- [x] `npm run test` — 14 files / 215 tests passed(+8 新規テスト)
- [x] ガイドライン add 中に 2 本指タッチするとガイド描画が破棄されピンチに切替(単体テストで検証)
- [x] 片方の指を離した後、残った 1 本指で画面がズレないこと(単体テストで検証)
- [x] 反転表示 (flip) でピンチ方向が意図どおり(単体テストで検証)
- [x] pinch 中は `getBoundingClientRect()` を touchmove ごとに呼ばない(単体テストで検証)
- [x] iPad Safari (PR preview) で実動作確認:
  - [x] Pexels 写真選択 → 2 本指ピンチで拡大縮小・パン
  - [x] SketchFab → モデル選択 → "Fix This Angle" → 2 本指ピンチ
- [ ] iPad Safari 実機、残り:
  - [ ] URL で画像指定 → 2 本指ピンチ
- [x] PC トラックパッドのピンチ/パンが従来どおり動作すること(リグレッション確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)