### PR TITLE
fix: preserve canvas zoom when toggling grid

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -176,27 +176,36 @@ export function DrawingCanvas({
     redrawAll()
   }, [highlightedStrokeIndex, redrawVersion, guideVersion, redrawAll])
 
+  // Latest-ref bridge so the effects below can read fresh fit/redraw without
+  // taking a dep on them — their identities churn on unrelated state (e.g.
+  // grid, highlightedStrokeIndex) and refiring fit would clobber the user's
+  // manual zoom.
+  const fitSizeRef = useRef(fitSize)
+  const fitToSizeRef = useRef(fitToSize)
+  const redrawAllRef = useRef(redrawAll)
+  useEffect(() => {
+    fitSizeRef.current = fitSize
+    fitToSizeRef.current = fitToSize
+    redrawAllRef.current = redrawAll
+  })
+
   // Reset view when viewResetVersion changes
   useEffect(() => {
     if (viewResetVersion > 0) {
-      if (fitSize) {
-        fitToSize()
+      if (fitSizeRef.current) {
+        fitToSizeRef.current()
       } else {
         viewTransformRef.current.reset()
       }
-      redrawAll()
+      redrawAllRef.current()
     }
-  }, [viewResetVersion, redrawAll, fitSize, fitToSize])
+  }, [viewResetVersion])
 
-  // fitToSize/redrawAll omitted from deps on purpose: their identities churn
-  // on unrelated state (e.g. highlightedStrokeIndex), which would refit and
-  // clobber the user's manual zoom.
   useEffect(() => {
     if (fitSize && isFitLeader) {
-      fitToSize()
-      redrawAll()
+      fitToSizeRef.current()
+      redrawAllRef.current()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fitSize, isFitLeader])
 
   const getCanvasPoint = useCallback((clientX: number, clientY: number): Point => {

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -218,16 +218,28 @@ export function ImageViewer({
     redraw()
   }, [redraw, isFitLeader])
 
-  // Load image: try without CORS first, then upgrade to CORS if possible
-  // Only depends on imageUrl to avoid re-triggering on prop changes
+  // Latest-ref bridge so effects below can read fresh callbacks without
+  // depending on them — fitImage churns whenever grid/guideLines change, and
+  // refiring it would clobber the user's manual zoom.
+  const fitImageRef = useRef(fitImage)
+  const onImageLoadedRef = useRef(onImageLoaded)
+  const onImageErrorRef = useRef(onImageError)
+  useEffect(() => {
+    fitImageRef.current = fitImage
+    onImageLoadedRef.current = onImageLoaded
+    onImageErrorRef.current = onImageError
+  })
+
+  // Load image: try without CORS first, then upgrade to CORS if possible.
+  // Re-runs only when the URL changes.
   useEffect(() => {
     let cancelled = false
 
     const applyImage = (loadedImg: HTMLImageElement) => {
       if (cancelled) return
       imageRef.current = loadedImg
-      onImageLoaded?.(loadedImg.naturalWidth, loadedImg.naturalHeight)
-      fitImage()
+      onImageLoadedRef.current?.(loadedImg.naturalWidth, loadedImg.naturalHeight)
+      fitImageRef.current()
     }
 
     const img = new Image()
@@ -241,12 +253,11 @@ export function ImageViewer({
       corsImg.src = imageUrl
     }
     img.onerror = () => {
-      if (!cancelled) onImageError?.()
+      if (!cancelled) onImageErrorRef.current?.()
     }
     img.src = imageUrl
 
     return () => { cancelled = true }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- only reload when URL changes
   }, [imageUrl])
 
   useEffect(() => {
@@ -259,8 +270,8 @@ export function ImageViewer({
 
   // Reset view
   useEffect(() => {
-    if (viewResetVersion > 0) fitImage()
-  }, [viewResetVersion, fitImage])
+    if (viewResetVersion > 0) fitImageRef.current()
+  }, [viewResetVersion])
 
   // Redraw when guides or overlay change
   useEffect(() => {


### PR DESCRIPTION
## Summary

- グリッドボタンで grid mode をサイクルするとキャンバスのズーム・パン状態が毎回 fit に戻ってしまうバグを修正。
- 原因は `viewResetVersion` を監視する useEffect の依存配列に `fitImage` / `fitToSize` / `redrawAll` が含まれており、grid 変化でこれらの identity が churn → `if (viewResetVersion > 0)` が再び真になって `ViewTransform.fitTo(...)` を呼んでしまっていた点。
- 呼び出す側のコールバックを latest-ref 経由にして、useEffect 本体の依存配列を `viewResetVersion` などの本来の入力だけに絞った。同じ churn 回避のために残っていた既存の `// eslint-disable-next-line react-hooks/exhaustive-deps` 2 箇所 (`DrawingCanvas.tsx`, `ImageViewer.tsx`) もこのパターンで置き換え、警告抑制を削除。
- `YouTubeViewer` は grid で churn する依存を持たないため変更なし。

## Test plan

- [x] `npm run lint` (no warnings, including `react-hooks/exhaustive-deps`)
- [x] `npm run test` (234 / 234 pass)
- [x] `npm run build` (success)
- [x] 実機で Reference = 画像 / YouTube / なし の各モードでピンチ・ホイールでズーム／パン後、両パネルのグリッドボタンで `none → normal → large → none` をサイクルし、ズーム・パン量が維持されることを確認
- [x] ズームリセットボタンは従来通り fit に戻ることを確認
- [x] 画像差し替え時（URL 入力 / ローカルファイル / Sketchfab "Fix This Angle" など）は初回の fit が効くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)