### PR TITLE
fix: sync grid pan with strokes when no reference is open

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -63,6 +63,7 @@ export function DrawingCanvas({
   const hasStylusRef = useRef(false)
   const drawingPointCountRef = useRef(0)
   const rafIdRef = useRef<number>(0)
+  const noRefGridCenterRef = useRef<Point>({ x: 0, y: 0 })
 
   // Pinch state
   const pinchRef = useRef<{ id1: number; id2: number; lastDist: number; lastMidX: number; lastMidY: number } | null>(null)
@@ -118,7 +119,7 @@ export function DrawingCanvas({
     const bottomRight = viewTransformRef.current.screenToCanvas(cssWidth, cssHeight)
     const gridCenter = fitSize
       ? { x: fitSize.width / 2, y: fitSize.height / 2 }
-      : viewTransformRef.current.screenToCanvas(cssWidth / 2, cssHeight / 2)
+      : noRefGridCenterRef.current
     drawGrid(ctx, grid, topLeft, bottomRight, vt.scale, gridCenter)
     drawGuideLines(ctx, guideLines, vt.scale)
 
@@ -153,6 +154,8 @@ export function DrawingCanvas({
     ctx.scale(dpr, dpr)
 
     rendererRef.current = new CanvasRenderer(ctx)
+
+    noRefGridCenterRef.current = { x: rect.width / 2, y: rect.height / 2 }
 
     // Resize does not refit — that would clobber the user's manual zoom/pan.
     // Fit happens only on fitSize change or viewResetVersion bump.

--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -155,7 +155,10 @@ export function DrawingCanvas({
 
     rendererRef.current = new CanvasRenderer(ctx)
 
-    noRefGridCenterRef.current = { x: rect.width / 2, y: rect.height / 2 }
+    noRefGridCenterRef.current = viewTransformRef.current.screenToCanvas(
+      rect.width / 2,
+      rect.height / 2,
+    )
 
     // Resize does not refit — that would clobber the user's manual zoom/pan.
     // Fit happens only on fitSize change or viewResetVersion bump.


### PR DESCRIPTION
## Summary

- 手本（リファレンス）を開いていない状態でスクロール（パン）すると、描線は動くのにグリッドが動かないバグを修正

## Root Cause

`DrawingCanvas.tsx` の `redrawAll` で、手本なし時のグリッドアンカーを毎フレーム `screenToCanvas(cssWidth/2, cssHeight/2)` で計算していた。この値はパンのたびに変わり（画面中心が指すキャンバス座標が変化するため）、ビュートランスフォームと打ち消し合ってグリッドが常に画面中心に貼り付いて見えていた。

## Fix

- `noRefGridCenterRef` を追加し、`setupCanvas` 実行時（コンテナサイズ確定時）に `(containerWidth/2, containerHeight/2)` をキャンバス空間の固定アンカーとして保存
- `redrawAll` でその固定値を参照するように変更
- リサイズ時は既存の ResizeObserver → `setupCanvas` パスで自動更新される

## Test plan

- [x] 手本なし状態でトラックパッド2本指スクロール（または iPad 2本指ドラッグ）→ グリッドと描線が同期して動くことを確認
- [x] 手本なし状態でズーム → 従来どおりグリッドと同期することを確認
- [x] ローカル画像・Sketchfab・YouTube を手本として開いた状態でパン・ズーム → リグレッションなしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)