### PR TITLE
fix: expand search browsers to fullscreen in portrait (#99)

### DIFF
--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -51,6 +51,16 @@ function SplitLayoutInner() {
       ? 'reference'
       : 'drawing'
 
+  // In portrait the split is top/bottom and the reference panel only gets
+  // half the height. While searching Sketchfab/Pexels (browse mode), give the
+  // reference panel the whole viewport so the result grid is browsable. The
+  // drawing panel is hidden via display:none rather than unmounted so its
+  // canvas/ViewTransform state survives the toggle.
+  const isSearchFullscreen =
+    !isLandscape &&
+    (source === 'sketchfab' || source === 'pexels') &&
+    referenceMode === 'browse'
+
   // Timer (lifted from DrawingPanel for autosave access)
   const timer = useTimer()
   const timerElapsedRef = useRef(timer.elapsedMs)
@@ -429,7 +439,7 @@ function SplitLayoutInner() {
           externalResetVersion={orientationResetVersion}
         />
       </Box>
-      <Box sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
+      <Box sx={{ flex: 1, minWidth: 0, minHeight: 0, display: isSearchFullscreen ? 'none' : 'block' }}>
         <DrawingPanel
           referenceSize={referenceSize}
           referenceInfo={referenceInfo}


### PR DESCRIPTION
Closes #99

## Summary

スマホ等の縦長レイアウトでは split が上下分割になり、リファレンスパネルが画面の縦半分しか使えないため、Sketchfab / Pexels の検索結果グリッドが見づらかった。
縦長 (`!isLandscape`) かつ Sketchfab/Pexels の `browse` モード中だけ、ドローイング側を `display: none` で畳んで、リファレンスパネルにビューポート全体を割り当てるようにした。

- 検索結果から項目を選ぶ、またはツールバー左端の既存 `X` ボタンで `source` を `'none'` に戻せば自動的に分割表示へ復帰
- 横向きでは従来どおり 50/50 分割（影響なし）
- `DrawingPanel` はアンマウントせず `display: none` で隠すだけなので、`DrawingCanvas` の DPR / fit / ViewTransform / `StrokeManager` の状態は維持される

差分は `src/components/SplitLayout.tsx` のみ、12 行。

## Test plan

- [x] `npm run lint` / `npm run build` / `npm run test` (262/262)
- [x] 縦長: Sketchfab・Pexels それぞれで browse → 全画面化、項目選択 / X ボタンで分割復帰
- [x] 横向き: 従来どおり 50/50 のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)