### PR TITLE
feat: add clear button and Enter-to-blur to Sketchfab/Pexels search

### DIFF
--- a/src/components/PexelsSearcher.tsx
+++ b/src/components/PexelsSearcher.tsx
@@ -5,11 +5,14 @@ import {
   Button,
   Chip,
   CircularProgress,
+  IconButton,
+  InputAdornment,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
   Typography,
 } from '@mui/material'
+import { X } from 'lucide-react'
 import {
   buildPexelsReferenceInfo,
   getPexelsApiKey,
@@ -60,6 +63,7 @@ export function PexelsSearcher({ onSelectPhoto, onOpenApiKeySettings, initialQue
   // Abort the in-flight search when a new one starts or when unmounting, so
   // a slow earlier response can't overwrite a faster later one.
   const inflightRef = useRef<AbortController | null>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
   useEffect(() => () => inflightRef.current?.abort(), [])
 
   useEffect(() => {
@@ -167,7 +171,32 @@ export function PexelsSearcher({ onSelectPhoto, onOpenApiKeySettings, initialQue
           placeholder={t('pexelsSearchPlaceholder')}
           value={query}
           onChange={e => setQuery(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter') void runSearch(query) }}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              void runSearch(query)
+              searchInputRef.current?.blur()
+            }
+          }}
+          inputRef={searchInputRef}
+          slotProps={{
+            input: {
+              endAdornment: query ? (
+                <InputAdornment position="end">
+                  <IconButton
+                    size="small"
+                    aria-label={t('clearSearch')}
+                    onClick={() => {
+                      setQuery('')
+                      searchInputRef.current?.focus()
+                    }}
+                    disabled={needsKey}
+                  >
+                    <X size={16} />
+                  </IconButton>
+                </InputAdornment>
+              ) : null,
+            },
+          }}
           sx={{ flex: 1 }}
           disabled={needsKey}
         />

--- a/src/components/SketchfabViewer.tsx
+++ b/src/components/SketchfabViewer.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { Box, Button, TextField, ToggleButton, ToggleButtonGroup, Typography, CircularProgress } from '@mui/material'
+import { Box, Button, IconButton, InputAdornment, TextField, ToggleButton, ToggleButtonGroup, Typography, CircularProgress } from '@mui/material'
+import { X } from 'lucide-react'
 import { t } from '../i18n'
 import type { ReferenceInfo } from '../types'
 
@@ -120,6 +121,7 @@ export function SketchfabViewer({ onFixAngle, onStateChange, actionsRef }: Sketc
   const [nextPageUrl, setNextPageUrl] = useState<string | null>(null)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const lastSearchRef = useRef<{ type: 'search'; query: string; category?: string } | { type: 'category'; slug: string } | null>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
   // Pending model UID to load once iframe is mounted
   const pendingLoadRef = useRef<string | null>(null)
 
@@ -335,7 +337,31 @@ export function SketchfabViewer({ onFixAngle, onStateChange, actionsRef }: Sketc
               placeholder={t('searchModels')}
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter') handleSearch(searchQuery) }}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  handleSearch(searchQuery)
+                  searchInputRef.current?.blur()
+                }
+              }}
+              inputRef={searchInputRef}
+              slotProps={{
+                input: {
+                  endAdornment: searchQuery ? (
+                    <InputAdornment position="end">
+                      <IconButton
+                        size="small"
+                        aria-label={t('clearSearch')}
+                        onClick={() => {
+                          setSearchQuery('')
+                          searchInputRef.current?.focus()
+                        }}
+                      >
+                        <X size={16} />
+                      </IconButton>
+                    </InputAdornment>
+                  ) : null,
+                },
+              }}
               sx={{ flex: 1 }}
             />
             <Button size="small" variant="contained" onClick={() => handleSearch(searchQuery)}>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -36,6 +36,7 @@ const messages = {
     // SketchfabViewer
     'searchModels': 'Search models...',
     'search': 'Search',
+    'clearSearch': 'Clear search',
     'modelUid': 'Model UID...',
     'load': 'Load',
     'loadingModel': 'Loading model...',
@@ -137,6 +138,7 @@ const messages = {
     // SketchfabViewer
     'searchModels': 'モデルを検索...',
     'search': '検索',
+    'clearSearch': '検索をクリア',
     'modelUid': 'モデルUID...',
     'load': '読込',
     'loadingModel': 'モデルを読み込み中...',


### PR DESCRIPTION
## Summary

- Sketchfab と Pexels の検索 `TextField` に clear (×) ボタンを追加。URL 欄が MUI Autocomplete から自動でもらえている挙動を、`InputAdornment` + lucide `X` で素朴に再現した。`value` が空でない時だけ表示し、押すと state を空にして input にフォーカスを戻すので、続けて新ワードを入力できる。
- 同じ2入力で、Enter による検索送信後に `inputRef.current?.blur()` を呼ぶようにした。スマホで検索したあとも貼り付いていたソフトキーボードがちゃんと閉じる。
- `src/i18n.ts` に aria-label 用の `clearSearch` を英日で追加（`Clear search` / `検索をクリア`）。
- Pexels 側は API キー未設定時 (`needsKey`) は clear ボタンも disabled にして、入力欄全体の disabled 状態と整合させている。

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (262 tests pass)
- [x] `npx tsc --noEmit`
- [ ] デスクトップブラウザ: Sketchfab / Pexels の検索欄に文字を入力 → × が表示される → クリックで空になり、フォーカスが残る
- [ ] デスクトップブラウザ: Pexels で API キー未設定時、検索欄も × も disabled になっている
- [ ] iPad Safari (or DevTools Device Mode): 検索欄でキーボードを出した状態で Enter → 検索が走り、ソフトキーボードが閉じる
- [ ] URL 欄の既存 × 動作にデグレがない

https://claude.ai/code/session_017Rt1uEXaN9z9EUCp2jjzpB

---
_Generated by [Claude Code](https://claude.ai/code/session_017Rt1uEXaN9z9EUCp2jjzpB)_