### PR TITLE
fix: keep Sketchfab 3D preview at half-screen in portrait

### DIFF
--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -229,6 +229,8 @@ interface ReferencePanelProps {
    * it adds an entry itself (e.g. Gallery "use this reference" reload).
    */
   onRegisterReloadUrlHistory?: (fn: () => void) => void
+  /** Notifies the parent when the Sketchfab 3D viewer iframe is mounted/unmounted. */
+  onSketchfabViewerStateChange?: (active: boolean) => void
   isFlipped?: boolean
   onToggleFlip?: () => void
   /** Optional shared ViewTransform for zoom sync with DrawingPanel. */
@@ -248,6 +250,7 @@ export function ReferencePanel({
   source, referenceMode, fixedImageUrl, localImageUrl, refInfo,
   onReferenceChange, onReferenceResetOnError,
   onRegisterLoadSketchfabModel, onRegisterReloadUrlHistory,
+  onSketchfabViewerStateChange,
   isFlipped, onToggleFlip,
   viewTransform, fitLeader, externalResetVersion,
 }: ReferencePanelProps) {
@@ -572,7 +575,8 @@ export function ReferencePanel({
   const handleSfStateChange = useCallback((state: { showViewer: boolean; isReady: boolean }) => {
     setSfShowViewer(state.showViewer)
     setSfIsReady(state.isReady)
-  }, [])
+    onSketchfabViewerStateChange?.(state.showViewer)
+  }, [onSketchfabViewerStateChange])
 
   // Load a Sketchfab model by UID (called from parent for gallery "load reference")
   const loadSketchfabModel = useCallback((uid: string) => {

--- a/src/components/SketchfabViewer.tsx
+++ b/src/components/SketchfabViewer.tsx
@@ -316,7 +316,7 @@ export function SketchfabViewer({ onFixAngle, onStateChange, actionsRef }: Sketc
             ref={iframeRef}
             title="Sketchfab Viewer"
             style={{ width: '100%', height: '100%', border: 'none' }}
-            allow="autoplay; fullscreen; xr-spatial-tracking"
+            allow="autoplay; fullscreen; xr-spatial-tracking; accelerometer; gyroscope; magnetometer"
           />
           {loading && (
             <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', bgcolor: 'rgba(255,255,255,0.8)', zIndex: 1 }}>

--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -42,6 +42,10 @@ function SplitLayoutInner() {
   const [referenceMode, setReferenceMode] = useState<ReferenceMode>('browse')
   const [fixedImageUrl, setFixedImageUrl] = useState<string | null>(null)
   const [localImageUrl, setLocalImageUrl] = useState<string | null>(null)
+  // Whether the Sketchfab 3D viewer iframe is currently mounted. While true,
+  // the reference panel must stay at half-screen so the preview matches the
+  // aspect ratio that "Fix This Angle" will capture.
+  const [sketchfabViewerActive, setSketchfabViewerActive] = useState(false)
 
   // The reference side can drive the fit when a fit-capable viewer is rendering
   // (ImageViewer for fixed-image sources, or YouTubeViewer which maps its iframe
@@ -58,10 +62,17 @@ function SplitLayoutInner() {
   // reference panel the whole viewport so the result grid is browsable. The
   // drawing panel is hidden via display:none rather than unmounted so its
   // canvas/ViewTransform state survives the toggle.
+  // Sketchfab's browse mode covers two screens (search results and the 3D
+  // viewer iframe); only the search-results screen should go fullscreen — the
+  // 3D viewer must stay half-height so the captured screenshot matches the
+  // visible camera framing.
   const isSearchFullscreen =
     !isLandscape &&
-    (source === 'sketchfab' || source === 'pexels') &&
-    referenceMode === 'browse'
+    referenceMode === 'browse' &&
+    (
+      (source === 'sketchfab' && !sketchfabViewerActive) ||
+      source === 'pexels'
+    )
 
   // Timer (lifted from DrawingPanel for autosave access)
   const timer = useTimer()
@@ -443,6 +454,7 @@ function SplitLayoutInner() {
           onReferenceResetOnError={resetReferenceOnError}
           onRegisterLoadSketchfabModel={handleRegisterLoadSketchfabModel}
           onRegisterReloadUrlHistory={handleRegisterReloadUrlHistory}
+          onSketchfabViewerStateChange={setSketchfabViewerActive}
           isFlipped={isFlipped}
           onToggleFlip={handleToggleFlip}
           viewTransform={viewTransform}

--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -45,7 +45,17 @@ function SplitLayoutInner() {
   // Whether the Sketchfab 3D viewer iframe is currently mounted. While true,
   // the reference panel must stay at half-screen so the preview matches the
   // aspect ratio that "Fix This Angle" will capture.
+  // SketchfabViewer is unmounted when source leaves 'sketchfab' and its unmount
+  // cannot push a "showViewer:false" notification, so reset on source change
+  // (via prev-state-in-render) to avoid a stale-active flicker on reopen.
   const [sketchfabViewerActive, setSketchfabViewerActive] = useState(false)
+  const [sfActiveTrackedSource, setSfActiveTrackedSource] = useState(source)
+  if (sfActiveTrackedSource !== source) {
+    setSfActiveTrackedSource(source)
+    if (source !== 'sketchfab' && sketchfabViewerActive) {
+      setSketchfabViewerActive(false)
+    }
+  }
 
   // The reference side can drive the fit when a fit-capable viewer is rendering
   // (ImageViewer for fixed-image sources, or YouTubeViewer which maps its iframe


### PR DESCRIPTION
## Summary

- 縦画面で Sketchfab のモデル選択後、3D プレビュー (Viewer API iframe) も全画面化されてしまう問題を修正
- 全画面化は検索結果グリッドのときだけ適用し、3D プレビュー以降は通常の半画面 split に戻すようにした
- 副次的に、iframe の `allow` 属性に `accelerometer; gyroscope; magnetometer` を追加(Sketchfab のモバイルレンダリング経路が出していた Permissions Policy 違反警告を解消)

## Background

PR #99/#100 (commit 55773db) で縦画面時に Sketchfab/Pexels の検索結果を全画面化したが、判定条件が `referenceMode === 'browse'` だけだったため、Sketchfab のモデル選択後の 3D プレビュー画面まで縦長の全画面で表示されていた。

これにより、

- 半画面で描画パネルと並べて見るべき画角がプレビュー段階で確認できない
- 「Fix This Angle」のスクリーンショット (1024x1024 固定) は iframe の縦横比に応じてカメラフレーミングが変わるため、プレビュー時 (縦長) と Fix 確定後 (半画面 = 横長寄り) で画角が一致しなくなる

という不具合が起きていた。

## Changes

- `SketchfabViewer` の既存 `onStateChange` (showViewer / isReady) を `ReferencePanel` 経由で `SplitLayout` まで持ち上げ、`sketchfabViewerActive` ローカル state として保持
- `isSearchFullscreen` の判定式を「Sketchfab のときは viewer がアクティブでない場合のみ」に絞り込み。Pexels は単一画面なので従来通り
- `ReferencePanel` に `onSketchfabViewerStateChange?: (active: boolean) => void` のオプショナル prop を追加
- `SketchfabViewer` の iframe `allow` に sensor 系を追加

永続化スキーマ (IndexedDB)・公開 API・横画面動作・既存 Pexels 動作は不変。

## Known Issue

PR と直接関係ないが、Chrome のモバイルエミュレーションで 3D プレビューの色が崩れる現象を発見 (#106、本 PR 以前から発生する pre-existing 問題)。`allow` 属性追加で console の Permissions Policy 警告は消えたものの、色問題は解消せず。

実機検証状況 (pr-preview):

- ✅ iPhone: 色は正常
- ⚠️ iPad: 未確認

iPhone で再現しないことから Chrome モバイルエミュレーション特有の挙動である可能性が高い。iPad での確認は #106 で継続。

## Test plan

- [x] `npm run lint` パス
- [x] `npm run build` パス
- [x] `npm run test` パス (既存 301 テスト)
- [x] pr-preview デプロイで以下を確認:
  - [x] 縦画面で Sketchfab → 検索結果が全画面 (従来通り)
  - [x] 検索結果からモデル選択 → 3D プレビューが半画面 (上半分)、下半分に DrawingPanel
  - [x] Fix This Angle で取った画像の画角がプレビュー時と一致
  - [x] Back で検索画面に戻ると再び全画面
  - [x] Pexels の挙動が変わっていない (検索全画面、写真選択で半画面)
  - [x] 横画面で常に 1:1 split (回帰なし)
  - [x] 実機 iPhone で 3D プレビューの色が正常
  - [ ] 実機 iPad で 3D プレビューの色が正常 (#106 で追跡)

🤖 Generated with [Claude Code](https://claude.com/claude-code)