### PR TITLE
fix: thinner gallery thumbnail strokes and align card date row

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -405,14 +405,14 @@ function DrawingCard({
         />
       )}
       <Box sx={{ p: 1 }}>
+        <Typography variant="caption" sx={{ display: 'block', color: 'text.secondary' }}>
+          {cardDateFormatter.format(new Date(drawing.createdAt))} / {formatTime(drawing.elapsedMs)}
+        </Typography>
         {refLabel && (
           <Typography variant="caption" sx={{ display: 'block', fontWeight: 'bold', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {refLabel}
           </Typography>
         )}
-        <Typography variant="caption" sx={{ display: 'block', color: 'text.secondary' }}>
-          {cardDateFormatter.format(new Date(drawing.createdAt))} / {formatTime(drawing.elapsedMs)}
-        </Typography>
         <Box sx={{ display: 'flex', gap: 0.5, mt: 0.5, alignItems: 'center' }}>
           {showReferenceButton && (
             <>

--- a/src/storage/generateThumbnail.ts
+++ b/src/storage/generateThumbnail.ts
@@ -43,7 +43,7 @@ export function generateThumbnail(strokes: readonly Stroke[]): string {
   ctx.translate(-minX + padding, -minY + padding)
 
   ctx.strokeStyle = '#000000'
-  ctx.lineWidth = 2 / scale
+  ctx.lineWidth = Math.max(2, 0.75 / scale)
   ctx.lineCap = 'round'
   ctx.lineJoin = 'round'
 


### PR DESCRIPTION
## Summary

- **Thumbnail stroke width**: `generateThumbnail` previously set `lineWidth = 2 / scale`, which kept the output line at 2 output-pixels regardless of how much the drawing was scaled down to fit the 200px thumbnail. For large drawings this produced lines roughly 5–6× thicker (relative to the bounding box) than what the user saw on the main canvas, making thumbnails look noticeably different from the original. Switched to `Math.max(2, 0.75 / scale)` so the relative thickness matches `CanvasRenderer`'s default 2px in logical space, with a 0.75 output-pixel floor so very large drawings still render visible lines.
- **Gallery card layout**: moved the date / elapsed-time row above the reference label. Previously cards with a reference showed `refLabel → date`, while cards without one showed only the date — so the date drifted vertically depending on whether a reference existed. With the date pinned to the top, its position is consistent across all cards.

Note: existing thumbnails are stored as PNGs in IndexedDB and are not re-generated. Only newly saved drawings will use the thinner stroke.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (304 passed)
- [x] Visual check: save a new drawing on a small bbox and a large bbox, confirm thumbnail stroke thickness matches the on-canvas impression
- [x] Visual check: gallery cards with and without a reference have the date row aligned at the same vertical position

🤖 Generated with [Claude Code](https://claude.com/claude-code)