### PR TITLE
fix: suppress toolbar tooltip misfire after stroke on iOS Safari

### DIFF
--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useCallback, useEffect, useMemo } from 'react'
-import { Box, IconButton, Tooltip, Button, Typography } from '@mui/material'
+import { Box, IconButton, Button, Typography } from '@mui/material'
+import { ToolbarTooltip } from './ToolbarTooltip'
 import { Pen, Eraser, Undo2, Redo2, Trash2, LocateFixed, Save, Check, Images } from 'lucide-react'
 import { DrawingCanvas, type DrawingMode } from './DrawingCanvas'
 import type { ViewTransform } from '../drawing/ViewTransform'
@@ -197,7 +198,7 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
         }}
       >
         {/* Drawing tools */}
-        <Tooltip title={`${t('pen')} (P)`}>
+        <ToolbarTooltip title={`${t('pen')} (P)`}>
           <IconButton
             size="small"
             onClick={handlePenTool}
@@ -209,9 +210,9 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
           >
             <Pen size={20} />
           </IconButton>
-        </Tooltip>
+        </ToolbarTooltip>
 
-        <Tooltip title={`${t('eraser')} (E)`}>
+        <ToolbarTooltip title={`${t('eraser')} (E)`}>
           <IconButton
             size="small"
             onClick={handleEraserTool}
@@ -223,43 +224,43 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
           >
             <Eraser size={20} />
           </IconButton>
-        </Tooltip>
+        </ToolbarTooltip>
 
         <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
 
         {/* Edit */}
-        <Tooltip title={`${t('undo')} (${mod}Z)`}>
+        <ToolbarTooltip title={`${t('undo')} (${mod}Z)`}>
           <span>
             <IconButton size="small" onClick={handleUndo} disabled={!canUndo}>
               <Undo2 size={20} />
             </IconButton>
           </span>
-        </Tooltip>
+        </ToolbarTooltip>
 
-        <Tooltip title={`${t('redo')} (${mod}Shift+Z)`}>
+        <ToolbarTooltip title={`${t('redo')} (${mod}Shift+Z)`}>
           <span>
             <IconButton size="small" onClick={handleRedo} disabled={!canRedo}>
               <Redo2 size={20} />
             </IconButton>
           </span>
-        </Tooltip>
+        </ToolbarTooltip>
 
-        <Tooltip title={t('clearAll')}>
+        <ToolbarTooltip title={t('clearAll')}>
           <span>
             <IconButton size="small" onClick={handleClear} disabled={strokeCount === 0}>
               <Trash2 size={20} />
             </IconButton>
           </span>
-        </Tooltip>
+        </ToolbarTooltip>
 
         <Box sx={{ flex: 1 }} />
 
         {/* View */}
-        <Tooltip title={t('resetZoom')}>
+        <ToolbarTooltip title={t('resetZoom')}>
           <IconButton size="small" onClick={() => setViewResetVersion(v => v + 1)}>
             <LocateFixed size={20} />
           </IconButton>
-        </Tooltip>
+        </ToolbarTooltip>
 
         <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
 
@@ -277,7 +278,7 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
           {formatTime(timer.elapsedMs)}
         </Typography>
 
-        <Tooltip title={saved ? t('saved') : `${t('saveDrawing')} (${mod}S)`}>
+        <ToolbarTooltip title={saved ? t('saved') : `${t('saveDrawing')} (${mod}S)`}>
           <span>
             <IconButton
               size="small"
@@ -293,13 +294,13 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
               {saved ? <Check size={20} /> : <Save size={20} />}
             </IconButton>
           </span>
-        </Tooltip>
+        </ToolbarTooltip>
 
-        <Tooltip title={t('gallery')}>
+        <ToolbarTooltip title={t('gallery')}>
           <IconButton size="small" onClick={() => { timer.pause(); setShowGallery(true) }}>
             <Images size={20} />
           </IconButton>
-        </Tooltip>
+        </ToolbarTooltip>
 
         {/* Eraser confirmation */}
         {highlightedStrokeIndex !== null && (

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { Box, Typography, IconButton, Tooltip, Button, ToggleButton, ToggleButtonGroup } from '@mui/material'
+import { Box, Typography, IconButton, Button, ToggleButton, ToggleButtonGroup } from '@mui/material'
+import { ToolbarTooltip } from './ToolbarTooltip'
 import { X, Trash2, ChevronDown, ChevronRight } from 'lucide-react'
 import {
   getAllDrawings,
@@ -436,14 +437,14 @@ function DrawingCard({
             </>
           )}
           <Box sx={{ flex: 1 }} />
-          <Tooltip title={t('delete')}>
+          <ToolbarTooltip title={t('delete')}>
             <IconButton
               size="small"
               onClick={() => drawing.id != null && onDelete(drawing.id)}
             >
               <Trash2 size={20} />
             </IconButton>
-          </Tooltip>
+          </ToolbarTooltip>
         </Box>
       </Box>
     </Box>

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
-import { Box, Button, Tooltip, IconButton, Typography, TextField, Link as MuiLink, Autocomplete } from '@mui/material'
+import { Box, Button, IconButton, Typography, TextField, Link as MuiLink, Autocomplete } from '@mui/material'
+import { ToolbarTooltip } from './ToolbarTooltip'
 import { X, PenLine, CircleX, Trash2, Layers, FlipHorizontal2, LocateFixed, Maximize, Minimize, Info, Film, Camera, Image as ImageIcon, Play, Pause, ZoomIn, Boxes, FolderOpen, KeyRound } from 'lucide-react'
 import { SketchfabViewer, type SketchfabActions } from './SketchfabViewer'
 import { ImageViewer, type GuideInteractionMode } from './ImageViewer'
@@ -130,7 +131,7 @@ function ReferenceInfoOverlay({ refInfo }: { refInfo: ReferenceInfo }) {
       pointerEvents: 'none',
     }}>
       {collapsed ? (
-        <Tooltip title={t('expandReferenceInfo')}>
+        <ToolbarTooltip title={t('expandReferenceInfo')}>
           <IconButton
             size="small"
             onClick={() => setCollapsed(false)}
@@ -144,7 +145,7 @@ function ReferenceInfoOverlay({ refInfo }: { refInfo: ReferenceInfo }) {
           >
             <Info size={18} />
           </IconButton>
-        </Tooltip>
+        </ToolbarTooltip>
       ) : (
         <Box sx={{
           display: 'flex',
@@ -185,7 +186,7 @@ function ReferenceInfoOverlay({ refInfo }: { refInfo: ReferenceInfo }) {
               </Typography>
             )}
           </Box>
-          <Tooltip title={t('collapseReferenceInfo')}>
+          <ToolbarTooltip title={t('collapseReferenceInfo')}>
             <IconButton
               size="small"
               onClick={() => setCollapsed(true)}
@@ -199,7 +200,7 @@ function ReferenceInfoOverlay({ refInfo }: { refInfo: ReferenceInfo }) {
             >
               <X size={14} />
             </IconButton>
-          </Tooltip>
+          </ToolbarTooltip>
         </Box>
       )}
     </Box>
@@ -655,11 +656,11 @@ export function ReferencePanel({
       >
         {/* Close button (when source is set) */}
         {!isNone && (
-          <Tooltip title={t('cancel')}>
+          <ToolbarTooltip title={t('cancel')}>
             <IconButton size="small" onClick={handleClose}>
               <X size={20} />
             </IconButton>
-          </Tooltip>
+          </ToolbarTooltip>
         )}
 
         {/* Sketchfab model viewer: Back to search results */}
@@ -692,7 +693,7 @@ export function ReferencePanel({
 
         {/* Works in both modes — pausing shouldn't require giving up zoom. */}
         {isYouTube && (
-          <Tooltip title={youtubePlaying ? t('youtubePause') : t('youtubePlay')}>
+          <ToolbarTooltip title={youtubePlaying ? t('youtubePause') : t('youtubePlay')}>
             <IconButton
               size="small"
               onClick={() => {
@@ -705,11 +706,11 @@ export function ReferencePanel({
             >
               {youtubePlaying ? <Pause size={20} /> : <Play size={20} />}
             </IconButton>
-          </Tooltip>
+          </ToolbarTooltip>
         )}
 
         {isYouTube && youtubeVideoInteractMode && (
-          <Tooltip title={t('youtubeReturnToZoom')}>
+          <ToolbarTooltip title={t('youtubeReturnToZoom')}>
             <IconButton
               size="small"
               aria-label={t('youtubeReturnToZoom')}
@@ -722,7 +723,7 @@ export function ReferencePanel({
             >
               <ZoomIn size={20} />
             </IconButton>
-          </Tooltip>
+          </ToolbarTooltip>
         )}
 
         {/* Guide line tools — add/delete-mode require a viewer to interact with. */}
@@ -730,7 +731,7 @@ export function ReferencePanel({
           <>
             <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
 
-            <Tooltip title={t('addGuideLine')}>
+            <ToolbarTooltip title={t('addGuideLine')}>
               <IconButton
                 size="small"
                 onClick={() => toggleGuideMode('add')}
@@ -742,9 +743,9 @@ export function ReferencePanel({
               >
                 <PenLine size={20} />
               </IconButton>
-            </Tooltip>
+            </ToolbarTooltip>
 
-            <Tooltip title={t('deleteGuideLine')}>
+            <ToolbarTooltip title={t('deleteGuideLine')}>
               <span>
                 <IconButton
                   size="small"
@@ -759,15 +760,15 @@ export function ReferencePanel({
                   <CircleX size={20} />
                 </IconButton>
               </span>
-            </Tooltip>
+            </ToolbarTooltip>
 
-            <Tooltip title={t('clearGuideLines')}>
+            <ToolbarTooltip title={t('clearGuideLines')}>
               <span>
                 <IconButton size="small" onClick={clearLines} disabled={lines.length === 0}>
                   <Trash2 size={20} />
                 </IconButton>
               </span>
-            </Tooltip>
+            </ToolbarTooltip>
           </>
         )}
 
@@ -776,11 +777,11 @@ export function ReferencePanel({
         {!(isFixed || isYouTube) && lines.length > 0 && (
           <>
             <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
-            <Tooltip title={t('clearGuideLines')}>
+            <ToolbarTooltip title={t('clearGuideLines')}>
               <IconButton size="small" onClick={clearLines}>
                 <Trash2 size={20} />
               </IconButton>
-            </Tooltip>
+            </ToolbarTooltip>
           </>
         )}
 
@@ -801,7 +802,7 @@ export function ReferencePanel({
 
         {/* View controls (always visible) */}
         {(isFixed || isYouTube) && !inYouTubeVideoMode && (
-          <Tooltip title={t('compare')}>
+          <ToolbarTooltip title={t('compare')}>
             <IconButton
               size="small"
               onClick={onToggleOverlay}
@@ -813,10 +814,10 @@ export function ReferencePanel({
             >
               <Layers size={20} />
             </IconButton>
-          </Tooltip>
+          </ToolbarTooltip>
         )}
 
-        <Tooltip title={t('cycleGrid')}>
+        <ToolbarTooltip title={t('cycleGrid')}>
           <IconButton
             size="small"
             onClick={cycleGridMode}
@@ -828,10 +829,10 @@ export function ReferencePanel({
           >
             <GridIcon mode={grid.mode} />
           </IconButton>
-        </Tooltip>
+        </ToolbarTooltip>
 
         {!isYouTube && (
-          <Tooltip title={t('flipHorizontal')}>
+          <ToolbarTooltip title={t('flipHorizontal')}>
             <IconButton
               size="small"
               onClick={onToggleFlip}
@@ -843,23 +844,23 @@ export function ReferencePanel({
             >
               <FlipHorizontal2 size={20} />
             </IconButton>
-          </Tooltip>
+          </ToolbarTooltip>
         )}
 
         {isFixed && (
-          <Tooltip title={t('resetZoom')}>
+          <ToolbarTooltip title={t('resetZoom')}>
             <IconButton size="small" onClick={() => setViewResetVersion(v => v + 1)}>
               <LocateFixed size={20} />
             </IconButton>
-          </Tooltip>
+          </ToolbarTooltip>
         )}
 
         {fullscreenSupported && (
-          <Tooltip title={isFullscreen ? t('exitFullscreen') : t('fullscreen')}>
+          <ToolbarTooltip title={isFullscreen ? t('exitFullscreen') : t('fullscreen')}>
             <IconButton size="small" onClick={toggleFullscreen}>
               {isFullscreen ? <Minimize size={20} /> : <Maximize size={20} />}
             </IconButton>
-          </Tooltip>
+          </ToolbarTooltip>
         )}
       </Box>
 
@@ -922,14 +923,14 @@ export function ReferencePanel({
                     </Typography>
                   </Box>
                 </Button>
-                <Tooltip title={t('pexelsApiKeySettings')}>
+                <ToolbarTooltip title={t('pexelsApiKeySettings')}>
                   <IconButton
                     onClick={() => setPexelsKeyDialogOpen(true)}
                     sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, px: 1.5 }}
                   >
                     <KeyRound size={18} />
                   </IconButton>
-                </Tooltip>
+                </ToolbarTooltip>
               </Box>
             </Box>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, width: '100%', maxWidth: 480 }}>
@@ -1047,7 +1048,7 @@ export function ReferencePanel({
                           </Typography>
                         )}
                       </Box>
-                      <Tooltip title={t('urlHistoryDelete')}>
+                      <ToolbarTooltip title={t('urlHistoryDelete')}>
                         <IconButton
                           size="small"
                           aria-label={t('urlHistoryDelete')}
@@ -1062,7 +1063,7 @@ export function ReferencePanel({
                         >
                           <Trash2 size={14} />
                         </IconButton>
-                      </Tooltip>
+                      </ToolbarTooltip>
                     </li>
                   )
                 }}

--- a/src/components/ToolbarTooltip.tsx
+++ b/src/components/ToolbarTooltip.tsx
@@ -1,0 +1,11 @@
+import { Tooltip, type TooltipProps } from '@mui/material'
+
+export function ToolbarTooltip(props: TooltipProps) {
+  return (
+    <Tooltip
+      disableTouchListener
+      disableFocusListener
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

- iPhone Safari でツールバーボタン (Pen / Eraser / Undo / Redo / Trash / Save / Gallery / Guide / Compare / Grid / Flip / Fullscreen 等) をタップ後にキャンバスでストロークを描き、指を離した瞬間に直前タップしたボタンのツールチップが表示される誤発火を解消
- ツールバー用の薄い Tooltip ラッパー `ToolbarTooltip` を新設し、`disableTouchListener` / `disableFocusListener` をデフォルト有効化。`DrawingPanel` / `ReferencePanel` / `Gallery` の Tooltip を一律置換
- デスクトップ (Mac Chrome 等) のマウスホバーによるツールチップ表示は変更なし

## Why

iOS Safari は touch シーケンス完了時に直前タップ要素へ合成 `mouseover` を遅延配送し、また `:focus` / `:hover` が sticky に残る挙動があるため、MUI Tooltip の touch / focus listener が描画完了の `touchend` のタイミングで発火していました。`disableHoverListener` まで付けるとデスクトップの利便性が落ちるため、touch / focus 経路だけを塞ぐ方針です。

## Test plan

- [x] `npm run lint` クリーン
- [x] `npm run test` 全 310 件パス
- [x] `npm run build` 成功
- [x] iPhone Safari 実機: 各ツールバーボタン → ストローク → 指離しでツールチップが出ないこと
- [ ] iPad + Apple Pencil 実機: 同上
- [ ] Mac Chrome / Safari: マウスホバーでツールチップが従来通り表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)