### PR TITLE
feat: disable view reset button when already at fit baseline

### DIFF
--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -57,6 +57,7 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
   const [canRedo, setCanRedo] = useState(false)
   const [redrawVersion, setRedrawVersion] = useState(0)
   const [viewResetVersion, setViewResetVersion] = useState(0)
+  const [, setViewTick] = useState(0)
   const [showGallery, setShowGallery] = useState(false)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -67,6 +68,15 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
   useEffect(() => {
     onStrokeManagerReady?.(strokeManagerRef.current)
   }, [onStrokeManagerReady])
+
+  // Re-render when the shared ViewTransform changes so the reset button can
+  // reflect the current dirty state.
+  useEffect(() => {
+    if (!viewTransform) return
+    return viewTransform.subscribe(() => setViewTick(t => t + 1))
+  }, [viewTransform])
+
+  const resetDisabled = viewTransform ? !viewTransform.isDirty() : false
 
   // Sync UI state after restore
   useEffect(() => {
@@ -257,9 +267,15 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
 
         {/* View */}
         <ToolbarTooltip title={t('resetZoom')}>
-          <IconButton size="small" onClick={() => setViewResetVersion(v => v + 1)}>
-            <LocateFixed size={20} />
-          </IconButton>
+          <span>
+            <IconButton
+              size="small"
+              onClick={() => setViewResetVersion(v => v + 1)}
+              disabled={resetDisabled}
+            >
+              <LocateFixed size={20} />
+            </IconButton>
+          </span>
         </ToolbarTooltip>
 
         <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -258,6 +258,7 @@ export function ReferencePanel({
   const { grid, lines, version: guideVersion, cycleGridMode, addLine, removeLine, clearLines } = useGuides()
   const { isFullscreen, toggleFullscreen, isSupported: fullscreenSupported } = useFullscreen()
   const [viewResetVersion, setViewResetVersion] = useState(0)
+  const [, setViewTick] = useState(0)
   const [guideMode, setGuideMode] = useState<GuideInteractionMode>('none')
   const [highlightedGuideId, setHighlightedGuideId] = useState<string | null>(null)
   const [urlInput, setUrlInput] = useState('')
@@ -312,6 +313,15 @@ export function ReferencePanel({
   }, [onRegisterReloadUrlHistory, reloadUrlHistory])
 
   const combinedResetVersion = viewResetVersion + (externalResetVersion ?? 0)
+
+  // Re-render when the shared ViewTransform changes so the reset button can
+  // reflect the current dirty state.
+  useEffect(() => {
+    if (!viewTransform) return
+    return viewTransform.subscribe(() => setViewTick(t => t + 1))
+  }, [viewTransform])
+
+  const resetDisabled = viewTransform ? !viewTransform.isDirty() : false
 
   // Sketchfab viewer state (reported by child)
   const [sfShowViewer, setSfShowViewer] = useState(false)
@@ -849,9 +859,15 @@ export function ReferencePanel({
 
         {isFixed && (
           <ToolbarTooltip title={t('resetZoom')}>
-            <IconButton size="small" onClick={() => setViewResetVersion(v => v + 1)}>
-              <LocateFixed size={20} />
-            </IconButton>
+            <span>
+              <IconButton
+                size="small"
+                onClick={() => setViewResetVersion(v => v + 1)}
+                disabled={resetDisabled}
+              >
+                <LocateFixed size={20} />
+              </IconButton>
+            </span>
           </ToolbarTooltip>
         )}
 

--- a/src/drawing/ViewTransform.test.ts
+++ b/src/drawing/ViewTransform.test.ts
@@ -99,6 +99,37 @@ describe('ViewTransform', () => {
     })
   })
 
+  describe('isDirty', () => {
+    it('starts clean', () => {
+      expect(vt.isDirty()).toBe(false)
+    })
+
+    it('becomes dirty after applyPinch', () => {
+      vt.applyPinch(0, 0, 2, 0, 0)
+      expect(vt.isDirty()).toBe(true)
+    })
+
+    it('becomes clean after reset', () => {
+      vt.applyPinch(0, 0, 2, 0, 0)
+      vt.reset()
+      expect(vt.isDirty()).toBe(false)
+    })
+
+    it('becomes clean after fitTo', () => {
+      vt.applyPinch(0, 0, 2, 0, 0)
+      vt.fitTo({ width: 100, height: 100 }, { width: 50, height: 50 })
+      expect(vt.isDirty()).toBe(false)
+    })
+
+    it('notifies listeners when dirty flag flips', () => {
+      const states: boolean[] = []
+      vt.subscribe(() => states.push(vt.isDirty()))
+      vt.applyPinch(0, 0, 2, 0, 0)
+      vt.reset()
+      expect(states).toEqual([true, false])
+    })
+  })
+
   describe('subscribe', () => {
     it('notifies listener when applyPinch is called', () => {
       const listener = vi.fn()

--- a/src/drawing/ViewTransform.ts
+++ b/src/drawing/ViewTransform.ts
@@ -17,6 +17,7 @@ const MAX_SCALE = 8
 
 export class ViewTransform {
   private transform: Transform
+  private dirty = false
   private listeners = new Set<() => void>()
 
   constructor(initial?: Transform) {
@@ -27,8 +28,13 @@ export class ViewTransform {
     return { ...this.transform }
   }
 
+  isDirty(): boolean {
+    return this.dirty
+  }
+
   reset(): void {
     this.transform = { ...IDENTITY_TRANSFORM }
+    this.dirty = false
     this.notify()
   }
 
@@ -41,6 +47,7 @@ export class ViewTransform {
     this.transform.offsetX = focalX - actualScaleDelta * (focalX - this.transform.offsetX) + translateX
     this.transform.offsetY = focalY - actualScaleDelta * (focalY - this.transform.offsetY) + translateY
     this.transform.scale = newScale
+    this.dirty = true
     this.notify()
   }
 
@@ -50,6 +57,7 @@ export class ViewTransform {
     this.transform.offsetX = (container.width - content.width * scale) / 2
     this.transform.offsetY = (container.height - content.height * scale) / 2
     this.transform.scale = scale
+    this.dirty = false
     this.notify()
   }
 


### PR DESCRIPTION
## Summary
- ドローパネル・参照パネルのズーム/スクロールリセットボタン (`LocateFixed`) が、すでにリセット済み(=ピンチ/パンされていない初期状態)のときに薄く表示されて押せなくなるようにした
- `ViewTransform` に `dirty` フラグを追加し、`applyPinch()` でセット、`reset()`/`fitTo()` でクリア。両パネルは shared transform を `subscribe()` で購読して再レンダリング
- shared `ViewTransform` を共有しているため、片方のパネルでパン/ズームすればもう片方のリセットボタンも同期して有効化される

## Test plan
- [x] `npm run lint` パス
- [x] `npm run test` パス (344 tests, `isDirty` の単体テスト 5 件追加)
- [x] `npm run build` パス
- [x] 起動直後にドロー側のリセットボタンが disabled になっていること
- [x] トラックパッドピンチ / Ctrl+wheel でズーム → ボタンが有効化される
- [x] リセットボタンを押す → ボタンが再び disabled になり fit 状態に戻る
- [ ] wheel(Ctrl なし)でパン → ボタンが有効化される
- [ ] 参照を Local File で読み込み `isFixed` モードに入った状態で参照側ボタンも同様に動く
- [x] ドロー側で操作したときに参照側のボタンも同期して有効化される

🤖 Generated with [Claude Code](https://claude.com/claude-code)