### PR TITLE
fix: shrink eraser/guide-delete confirmation to icon buttons

### DIFF
--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, useCallback, useEffect, useMemo } from 'react'
-import { Box, IconButton, Button, Typography } from '@mui/material'
+import { Box, IconButton, Typography } from '@mui/material'
 import { ToolbarTooltip } from './ToolbarTooltip'
-import { Pen, Eraser, Undo2, Redo2, Trash2, LocateFixed, Save, Check, Images } from 'lucide-react'
+import { Pen, Eraser, Undo2, Redo2, Trash2, LocateFixed, Save, Check, Images, X } from 'lucide-react'
 import { DrawingCanvas, type DrawingMode } from './DrawingCanvas'
 import type { ViewTransform } from '../drawing/ViewTransform'
 import { StrokeManager } from '../drawing/StrokeManager'
@@ -322,12 +322,24 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
         {highlightedStrokeIndex !== null && (
           <>
             <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
-            <Button size="small" color="error" variant="contained" onClick={handleDeleteHighlighted}>
-              {t('delete')}
-            </Button>
-            <Button size="small" variant="outlined" onClick={handleCancelHighlight}>
-              {t('cancel')}
-            </Button>
+            <ToolbarTooltip title={t('delete')}>
+              <IconButton
+                size="small"
+                onClick={handleDeleteHighlighted}
+                sx={{
+                  bgcolor: 'error.main',
+                  color: 'white',
+                  '&:hover': { bgcolor: 'error.dark' },
+                }}
+              >
+                <Trash2 size={20} />
+              </IconButton>
+            </ToolbarTooltip>
+            <ToolbarTooltip title={t('cancel')}>
+              <IconButton size="small" onClick={handleCancelHighlight}>
+                <X size={20} />
+              </IconButton>
+            </ToolbarTooltip>
           </>
         )}
       </Box>

--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -294,34 +294,37 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
           {formatTime(timer.elapsedMs)}
         </Typography>
 
-        <ToolbarTooltip title={saved ? t('saved') : `${t('saveDrawing')} (${mod}S)`}>
-          <span>
-            <IconButton
-              size="small"
-              onClick={handleSave}
-              disabled={strokeCount === 0 || saving}
-              sx={{
-                bgcolor: saved ? 'success.main' : 'transparent',
-                color: saved ? 'white' : 'inherit',
-                '&:hover': { bgcolor: saved ? 'success.dark' : 'action.hover' },
-                transition: 'background-color 0.3s, color 0.3s',
-              }}
-            >
-              {saved ? <Check size={20} /> : <Save size={20} />}
-            </IconButton>
-          </span>
-        </ToolbarTooltip>
+        {highlightedStrokeIndex === null && (
+          <>
+            <ToolbarTooltip title={saved ? t('saved') : `${t('saveDrawing')} (${mod}S)`}>
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={handleSave}
+                  disabled={strokeCount === 0 || saving}
+                  sx={{
+                    bgcolor: saved ? 'success.main' : 'transparent',
+                    color: saved ? 'white' : 'inherit',
+                    '&:hover': { bgcolor: saved ? 'success.dark' : 'action.hover' },
+                    transition: 'background-color 0.3s, color 0.3s',
+                  }}
+                >
+                  {saved ? <Check size={20} /> : <Save size={20} />}
+                </IconButton>
+              </span>
+            </ToolbarTooltip>
 
-        <ToolbarTooltip title={t('gallery')}>
-          <IconButton size="small" onClick={() => { timer.pause(); setShowGallery(true) }}>
-            <Images size={20} />
-          </IconButton>
-        </ToolbarTooltip>
+            <ToolbarTooltip title={t('gallery')}>
+              <IconButton size="small" onClick={() => { timer.pause(); setShowGallery(true) }}>
+                <Images size={20} />
+              </IconButton>
+            </ToolbarTooltip>
+          </>
+        )}
 
-        {/* Eraser confirmation */}
+        {/* Eraser confirmation (replaces save/gallery in-place to keep the timer position stable) */}
         {highlightedStrokeIndex !== null && (
           <>
-            <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
             <ToolbarTooltip title={t('delete')}>
               <IconButton
                 size="small"

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -799,12 +799,24 @@ export function ReferencePanel({
         {highlightedGuideId && !inYouTubeVideoMode && (
           <>
             <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
-            <Button size="small" color="error" variant="contained" onClick={handleDeleteHighlighted}>
-              {t('delete')}
-            </Button>
-            <Button size="small" variant="outlined" onClick={handleCancelHighlight}>
-              {t('cancel')}
-            </Button>
+            <ToolbarTooltip title={t('delete')}>
+              <IconButton
+                size="small"
+                onClick={handleDeleteHighlighted}
+                sx={{
+                  bgcolor: 'error.main',
+                  color: 'white',
+                  '&:hover': { bgcolor: 'error.dark' },
+                }}
+              >
+                <Trash2 size={20} />
+              </IconButton>
+            </ToolbarTooltip>
+            <ToolbarTooltip title={t('cancel')}>
+              <IconButton size="small" onClick={handleCancelHighlight}>
+                <X size={20} />
+              </IconButton>
+            </ToolbarTooltip>
           </>
         )}
 


### PR DESCRIPTION
## Summary

スマホの縦持ち（iPhone SE クラスの ~375px 幅）で消しゴムを使い、線を選択して `削除` / `キャンセル` の確認ボタンを表示すると、ツールバーが画面幅からはみ出して折り返し、描画キャンバスが下にずれてしまっていました。

ツールバー（`src/components/DrawingPanel.tsx:198-209`）は `display: flex` の単一行コンテナで、レスポンシブな折り畳みロジックを持たないため、テキストボタン2つ（合計 150–200px 程度）が追加されると iPhone サイズの幅に収まらなくなっていたのが原因です。

- DrawingPanel の消しゴム確認ボタン（`削除` / `キャンセル`）を `Trash2` / `X` のアイコンのみの `IconButton` に置き換え（ツールバー他の操作と同じ見た目）。
- 同じパターンで存在していた ReferencePanel のガイド線削除確認ボタンも揃えて修正。
- ラベルは既存の `ToolbarTooltip` で tooltip として保持（i18n の `t('delete')` / `t('cancel')` をそのまま再利用）。
- 削除側はアクティブな消しゴムボタンと同じ `error.main` の塗りつぶしスタイルにして、破壊的操作であることを視覚的に示しています。

確認ボタン2つの占有幅は ~150–200px → ~64px に縮み、iPhone SE 相当の幅でもツールバーが1行に収まり、キャンバスのズレは発生しません。

## Test plan

- [ ] `npm run dev` を起動し、Chrome DevTools のデバイスツールバーで iPhone SE (375 × 667) を選択
- [ ] 線を1本描く → 消しゴムに切り替え → 線をタップ → 赤いゴミ箱アイコン + ✕ アイコンが1行内に表示され、キャンバスがずれないことを確認
- [ ] ゴミ箱アイコンタップ → 線が削除され、確認ボタンが消える
- [ ] もう一度線をタップ → ✕ アイコンタップ → ハイライトが解除され、確認ボタンが消える
- [ ] 各アイコンを長押し/ホバー → tooltip に `削除` / `キャンセル` が出る
- [ ] ReferencePanel 側でも、ガイド線を追加 → タップで選択 → 同じく1行に収まり、削除/キャンセルが動くことを確認
- [ ] 横向き（landscape）と PC 幅でも見た目が崩れないことを確認
- [ ] `npm run lint` / `npm run test` / `npm run build` が通る（ローカルで確認済み）

https://claude.ai/code/session_014oRkYn5EGHCm48ZycmgtXf

---
_Generated by [Claude Code](https://claude.ai/code/session_014oRkYn5EGHCm48ZycmgtXf)_