### PR TITLE
fix: preserve overlay compare mode when clearing canvas

### DIFF
--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -487,7 +487,7 @@ function SplitLayoutInner() {
           onStrokeManagerReady={handleStrokeManagerReady}
           onStrokesChanged={handleStrokesChanged}
           onCurrentStrokeChange={handleCurrentStrokeChange}
-          onOverlayClear={() => { setOverlayActive(false); setOverlayStrokes(null) }}
+          onOverlayClear={() => { setOverlayStrokes(null) }}
           onLoadReference={handleLoadReference}
           captureReferenceSnapshot={captureReferenceSnapshot}
           timer={timer}


### PR DESCRIPTION
## Summary
- ドロー画面のゴミ箱ボタン（キャンバス消去）を押した際、補助線・グリッド・ズーム・左右反転は維持されるのに対し、答え合わせモード（オーバーレイ比較モード）だけが OFF にリセットされていた。一貫性が無かったため、比較モードのトグル状態も維持するように修正。
- `SplitLayout.tsx` の `onOverlayClear` から `setOverlayActive(false)` を外し、キャッシュ済みストローク (`overlayStrokes`) のクリアのみ残した。新たにストロークを描けば既存の `handleStrokesChanged` が `overlayActive` を見て自動的に再投入するため、追加の配線は不要。

## Test plan
- [x] `npm run lint` パス
- [x] `npm run build` パス
- [x] `npm run test` パス（344 tests）
- [x] 手本表示 → ストロークを描く → 答え合わせモード ON → ゴミ箱押下 → トグルが ON のまま維持され、手本側の古いストロークは消えていることを確認
- [x] その状態で再度ストロークを描き、手本側にもリアルタイムで重なって表示されることを確認
- [ ] 答え合わせモード OFF の状態でゴミ箱を押した場合、OFF のままであることを確認（リグレッションが無いこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)