### PR TITLE
fix: scope flip mode to the reference image only

### DIFF
--- a/src/components/ImageViewer.test.tsx
+++ b/src/components/ImageViewer.test.tsx
@@ -156,4 +156,16 @@ describe('ImageViewer pinch gesture', () => {
     expect(focalX).toBeCloseTo(90)
     expect(focalY).toBeCloseTo(80)
   })
+
+  it('applies scaleX(-1) inline transform on the container when isFlipped is true', () => {
+    const { container } = render(<ImageViewer {...baseProps} guideMode="none" isFlipped />)
+    const outer = container.firstChild as HTMLElement
+    expect(outer.style.transform).toBe('scaleX(-1)')
+  })
+
+  it('does not apply a transform when isFlipped is false', () => {
+    const { container } = render(<ImageViewer {...baseProps} guideMode="none" />)
+    const outer = container.firstChild as HTMLElement
+    expect(outer.style.transform).toBe('')
+  })
 })

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -481,7 +481,11 @@ export function ImageViewer({
   const cursor = guideMode === 'add' ? 'crosshair' : guideMode === 'delete' ? 'pointer' : 'default'
 
   return (
-    <Box ref={containerRef} sx={{ width: '100%', height: '100%' }}>
+    <Box
+      ref={containerRef}
+      sx={{ width: '100%', height: '100%' }}
+      style={isFlipped ? { transform: 'scaleX(-1)' } : undefined}
+    >
       <canvas
         ref={canvasRef}
         onMouseDown={handleMouseDown}

--- a/src/components/ReferencePanel.test.tsx
+++ b/src/components/ReferencePanel.test.tsx
@@ -183,6 +183,34 @@ describe('ReferencePanel ObjectURL lifecycle (via SplitLayout)', () => {
     expect(refreshed.querySelector('.lucide-image')).not.toBeNull()
   })
 
+  it('does not flip the source-selection screen even when flip mode is on', async () => {
+    // Regression: the outer reference-content Box used to apply scaleX(-1)
+    // unconditionally, which made the source-selection / search UI text
+    // unreadable. Flip should now apply only to the ImageViewer container,
+    // not to the source-selection screen.
+    getUrlHistoryMock.mockResolvedValue([])
+
+    const { container } = render(<SplitLayout />)
+    await vi.waitFor(() => {
+      expect(screen.getByText('Sketchfab')).toBeInTheDocument()
+    })
+
+    // Toggle flip mode via the toolbar's lucide-icon button (no aria-label,
+    // so we locate it by its icon class).
+    const flipIcon = container.querySelector('.lucide-flip-horizontal-2')
+    expect(flipIcon).not.toBeNull()
+    const flipBtn = flipIcon!.closest('button') as HTMLButtonElement
+    fireEvent.click(flipBtn)
+
+    // Walk up from the "Sketchfab" source-selection button: no ancestor
+    // should carry an inline scaleX(-1) transform.
+    const sketchfabBtn = screen.getByText('Sketchfab').closest('button') as HTMLButtonElement
+    expect(sketchfabBtn).not.toBeNull()
+    for (let el: HTMLElement | null = sketchfabBtn; el; el = el.parentElement) {
+      expect(el.style.transform).not.toContain('scaleX(-1)')
+    }
+  })
+
   it('only creates ObjectURLs for image entries, not for url/youtube/pexels', async () => {
     // url/youtube/pexels resolve their thumbnails without holding a Blob, so
     // they must not contribute to the ObjectURL Map. Otherwise we'd be paying

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -893,7 +893,7 @@ export function ReferencePanel({
       </Box>
 
       {/* Content */}
-      <Box sx={{ flex: 1, minHeight: 0, position: 'relative', transform: (isFlipped && !isYouTube) ? 'scaleX(-1)' : undefined }}>
+      <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
         {/* No source: show selection buttons in center */}
         {isNone && (
           <Box sx={{ height: '100%', overflowY: 'auto' }}>


### PR DESCRIPTION
## Summary

- 左右反転トグルが `ReferencePanel` のコンテンツエリア全体に `scaleX(-1)` を適用していたため、初期画面のソース選択ボタン、Sketchfab / Pexels の検索 UI、`ReferenceInfoOverlay`（"Photo by ... · via Pexels" などのクレジット）まで鏡映しになって読めなくなっていた。
- 反転を `ImageViewer` の outer Box (inline style) に閉じ込め、ソース選択・検索・情報オーバーレイは反転しないようにした。固定画像（ローカル画像 / URL 画像 / Pexels 写真 / Sketchfab Fix Angle 後の静止画）は従来通り反転される。
- YouTubeViewer は元から非対象、DrawingPanel は既に Canvas のみに transform が当たっており変更なし。座標反転 (`screenX = rect.width - screenX`) は `getBoundingClientRect` ベースで CSS transform 付与位置に依存しないため挙動不変。

## Test plan

- [x] `npm run lint` 通過
- [x] `npm run build` 通過
- [x] `npm run test`（347 件）すべて通過
- [x] `ImageViewer.test.tsx` に `isFlipped` で outer Box の inline `transform: scaleX(-1)` が付与/未付与となることのテストを 2 件追加
- [x] `ReferencePanel.test.tsx` に「フリップモード ON でもソース選択画面の祖先に `scaleX(-1)` が現れない」リグレッションテストを 1 件追加
- [x] iPad / デスクトップで手動確認: 反転 ON 時、初期画面・Sketchfab browse・Pexels 検索・ReferenceInfoOverlay が正しい向きに保たれること
- [x] 反転 ON 時、固定画像とドローイングキャンバスが反転表示され、ピンチズーム / トラックパッドパン / Apple Pencil 描画の座標が引き続き整合すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)