### PR TITLE
Restore per-photo Pexels search context from URL history

### DIFF
--- a/src/components/PexelsSearcher.tsx
+++ b/src/components/PexelsSearcher.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Alert,
   Box,
@@ -16,15 +16,16 @@ import { X } from 'lucide-react'
 import {
   buildPexelsReferenceInfo,
   getPexelsApiKey,
+  getPexelsLastSearch,
   isAbortError,
   mapPexelsErrorKey,
   searchPhotos,
+  setPexelsLastSearch,
+  type PexelsOrientationFilter as Orientation,
   type PexelsPhoto,
 } from '../utils/pexels'
 import type { ReferenceInfo } from '../types'
 import { t } from '../i18n'
-
-type Orientation = 'all' | 'landscape' | 'portrait' | 'square'
 
 interface PexelsSearcherProps {
   onSelectPhoto: (info: Extract<ReferenceInfo, { source: 'pexels' }>, thumbnailUrl: string) => void
@@ -48,8 +49,12 @@ const SUGGESTED_QUERIES: { label: string; query: string }[] = [
 ]
 
 export function PexelsSearcher({ onSelectPhoto, onOpenApiKeySettings, initialQuery = '', apiKeyVersion = 0 }: PexelsSearcherProps) {
-  const [query, setQuery] = useState(initialQuery)
-  const [orientation, setOrientation] = useState<Orientation>('all')
+  // Restore last search so navigating back to the searcher (incl. via
+  // URL-history fixed → "back to search") shows the prior intent rather
+  // than an empty grid. initialQuery prop overrides the saved value.
+  const lastSearch = useMemo(() => getPexelsLastSearch(), [])
+  const [query, setQuery] = useState(initialQuery || lastSearch?.query || '')
+  const [orientation, setOrientation] = useState<Orientation>(lastSearch?.orientation ?? 'all')
   const [photos, setPhotos] = useState<PexelsPhoto[]>([])
   const [activeQuery, setActiveQuery] = useState('')
   const [activeOrientation, setActiveOrientation] = useState<Orientation>('all')
@@ -106,6 +111,7 @@ export function PexelsSearcher({ onSelectPhoto, onOpenApiKeySettings, initialQue
       setActiveOrientation(orientation)
       setCurrentPage(1)
       setHasMore(!!res.next_page && res.photos.length > 0)
+      setPexelsLastSearch(trimmed, orientation)
     } catch (e) {
       if (isAbortError(e)) return
       setError(handleError(e))
@@ -118,6 +124,16 @@ export function PexelsSearcher({ onSelectPhoto, onOpenApiKeySettings, initialQue
       }
     }
   }, [orientation, handleError])
+
+  // On first mount, if a saved query was restored (and the API key is set),
+  // re-run that search so "back to search" from a URL-history-loaded fixed
+  // photo lands on results instead of an empty grid. Deferred to a microtask
+  // so runSearch's setLoading() doesn't fire synchronously inside the effect.
+  useEffect(() => {
+    if (!query.trim() || needsKey) return
+    queueMicrotask(() => { void runSearch(query) })
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only auto-restore
+  }, [])
 
   const handleLoadMore = useCallback(async () => {
     if (!hasMore || loadingMore || !activeQuery) return

--- a/src/components/PexelsSearcher.tsx
+++ b/src/components/PexelsSearcher.tsx
@@ -31,6 +31,7 @@ interface PexelsSearcherProps {
   onSelectPhoto: (info: Extract<ReferenceInfo, { source: 'pexels' }>, thumbnailUrl: string) => void
   onOpenApiKeySettings: () => void
   initialQuery?: string
+  initialOrientation?: Orientation
   /** Bumped by parent when the API key changes so the searcher re-evaluates key state. */
   apiKeyVersion?: number
 }
@@ -48,13 +49,14 @@ const SUGGESTED_QUERIES: { label: string; query: string }[] = [
   { label: 'hand', query: 'hand' },
 ]
 
-export function PexelsSearcher({ onSelectPhoto, onOpenApiKeySettings, initialQuery = '', apiKeyVersion = 0 }: PexelsSearcherProps) {
-  // Restore last search so navigating back to the searcher (incl. via
-  // URL-history fixed → "back to search") shows the prior intent rather
-  // than an empty grid. initialQuery prop overrides the saved value.
+export function PexelsSearcher({ onSelectPhoto, onOpenApiKeySettings, initialQuery, initialOrientation, apiKeyVersion = 0 }: PexelsSearcherProps) {
+  // Restore the prior search so navigating back to the searcher shows results
+  // rather than an empty grid. initial* props (passed by the parent when
+  // loading from URL history with per-photo context) take precedence over the
+  // global last-search snapshot in localStorage.
   const lastSearch = useMemo(() => getPexelsLastSearch(), [])
-  const [query, setQuery] = useState(initialQuery || lastSearch?.query || '')
-  const [orientation, setOrientation] = useState<Orientation>(lastSearch?.orientation ?? 'all')
+  const [query, setQuery] = useState(initialQuery ?? lastSearch?.query ?? '')
+  const [orientation, setOrientation] = useState<Orientation>(initialOrientation ?? lastSearch?.orientation ?? 'all')
   const [photos, setPhotos] = useState<PexelsPhoto[]>([])
   const [activeQuery, setActiveQuery] = useState('')
   const [activeOrientation, setActiveOrientation] = useState<Orientation>('all')

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -12,9 +12,11 @@ import { GitHubIcon } from './GitHubIcon'
 import { parseYouTubeVideoId, fetchYouTubeTitle } from '../utils/youtube'
 import {
   buildPexelsReferenceInfo,
+  getPexelsLastSearch,
   getPhoto,
   mapPexelsErrorKey,
   parsePexelsPhotoUrl,
+  type PexelsOrientationFilter,
 } from '../utils/pexels'
 import { addUrlHistory, getUrlHistory, getUrlHistoryEntry, deleteUrlHistory, type UrlHistoryEntry, type UrlHistoryType, type AddUrlHistoryOptions } from '../storage'
 import { resizeImageForHistory, sha256Hex } from '../utils/imageResize'
@@ -332,6 +334,16 @@ export function ReferencePanel({
   const [pexelsKeyDialogOpen, setPexelsKeyDialogOpen] = useState(false)
   const [pexelsKeyVersion, setPexelsKeyVersion] = useState(0)
 
+  // Per-URL-history-entry Pexels search context restore. Bumping `token`
+  // remounts PexelsSearcher with the entry's saved query+orientation so
+  // "back to search" returns to the search that originally produced this
+  // photo, not the most recent global search.
+  const [pexelsRestore, setPexelsRestore] = useState<{
+    token: number
+    query: string
+    orientation: PexelsOrientationFilter
+  } | null>(null)
+
   // videoInteractMode: overlay steps aside so the iframe receives clicks.
   // Entered automatically on single-tap, exited via the toolbar button.
   // playing: mirrors the iframe's own player state for the toolbar icon.
@@ -452,7 +464,7 @@ export function ReferencePanel({
       return
     }
 
-    // Pexels photo URL: resolve via API to fetch the CDN URL + photographer
+    // Pexels photo URL: resolve via API to fetch the CDN URL + photographer.
     const pexelsMatch = parsePexelsPhotoUrl(url)
     if (pexelsMatch) {
       getPhoto(pexelsMatch.id)
@@ -466,10 +478,25 @@ export function ReferencePanel({
             s.setReferenceInfo(info)
           })
           setUrlInput('')
+          // Don't pass pexelsSearchContext — addUrlHistory's preservation
+          // semantics keep the original context attached to this entry.
           void addAndReloadHistory(url, 'pexels', {
             title: info.title,
             thumbnailUrl: photo.src.tiny,
           })
+          // Restore the per-entry search context fire-and-forget so a slow /
+          // failing urlHistory read doesn't gate the reference state update.
+          getUrlHistoryEntry(url)
+            .then(entry => {
+              const ctx = entry?.pexelsSearchContext
+              if (!ctx) return
+              setPexelsRestore(prev => ({
+                token: (prev?.token ?? 0) + 1,
+                query: ctx.query,
+                orientation: ctx.orientation,
+              }))
+            })
+            .catch(() => { /* best-effort */ })
         })
         .catch(e => setUrlError(t(mapPexelsErrorKey(e))))
         .finally(() => setUrlLoading(false))
@@ -572,7 +599,15 @@ export function ReferencePanel({
       s.setReferenceInfo(info)
     })
     if (info.pexelsPageUrl) {
-      void addAndReloadHistory(info.pexelsPageUrl, 'pexels', { title: info.title, thumbnailUrl })
+      // runSearch saves to localStorage right before yielding the result list,
+      // so getPexelsLastSearch() here reflects the search that produced this
+      // photo. Persisting it per-entry lets URL-history loads restore the
+      // originating search context independently of the global last search.
+      void addAndReloadHistory(info.pexelsPageUrl, 'pexels', {
+        title: info.title,
+        thumbnailUrl,
+        pexelsSearchContext: getPexelsLastSearch() ?? undefined,
+      })
     }
   }, [onReferenceChange, addAndReloadHistory])
 
@@ -1155,13 +1190,18 @@ export function ReferencePanel({
 
         {/* Pexels searcher — kept mounted while source is 'pexels' so the
             search state (query, results, pagination, scroll) persists across
-            browse ↔ fixed transitions. Hidden when a photo is being viewed. */}
+            browse ↔ fixed transitions. Hidden when a photo is being viewed.
+            Bumping pexelsRestore.token via key remounts with the per-photo
+            search context restored from the URL-history entry. */}
         {source === 'pexels' && (
           <Box sx={{ display: referenceMode === 'browse' ? 'contents' : 'none' }}>
             <PexelsSearcher
+              key={pexelsRestore?.token ?? 0}
               onSelectPhoto={handleSelectPexelsPhoto}
               onOpenApiKeySettings={() => setPexelsKeyDialogOpen(true)}
               apiKeyVersion={pexelsKeyVersion}
+              initialQuery={pexelsRestore?.query}
+              initialOrientation={pexelsRestore?.orientation}
             />
           </Box>
         )}

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -2,6 +2,7 @@ import Dexie, { type EntityTable } from 'dexie'
 import type { Stroke } from '../drawing/types'
 import type { GuideLine, GridSettings } from '../guides/types'
 import type { ReferenceInfo, ReferenceSource } from '../types'
+import type { PexelsLastSearch } from '../utils/pexels'
 
 export interface DrawingRecord {
   id?: number
@@ -45,6 +46,12 @@ export interface UrlHistoryEntry {
    * render time, 'url' uses the entry url itself, and 'image' uses imageBlob.
    */
   thumbnailUrl?: string
+  /**
+   * For 'pexels' entries: the search query + orientation that produced this
+   * photo when it was selected. Restored when the entry is re-opened so
+   * "back to search" returns to the originating search context.
+   */
+  pexelsSearchContext?: PexelsLastSearch
 }
 
 // Scope database name by deploy path so PR previews don't share data.
@@ -91,6 +98,14 @@ db.version(5).stores({
 // v6: no index change — anchors the additive thumbnailUrl field on
 // UrlHistoryEntry (used for the dropdown preview thumbnail).
 db.version(6).stores({
+  drawings: '++id, createdAt',
+  session: 'id',
+  urlHistory: 'url, lastUsedAt',
+})
+
+// v7: no index change — anchors the additive pexelsSearchContext field on
+// UrlHistoryEntry (per-photo Pexels search context restoration).
+db.version(7).stores({
   drawings: '++id, createdAt',
   session: 'id',
   urlHistory: 'url, lastUsedAt',

--- a/src/storage/urlHistoryStore.ts
+++ b/src/storage/urlHistoryStore.ts
@@ -1,5 +1,6 @@
 import { db, type UrlHistoryEntry, type UrlHistoryType } from './db'
 import { buildYouTubeCanonicalUrl, parseYouTubeVideoId } from '../utils/youtube'
+import type { PexelsLastSearch } from '../utils/pexels'
 
 export const URL_HISTORY_LIMIT = 50
 // Images are stored with their Blob, so each entry can be 200KB–1.5MB.
@@ -12,6 +13,7 @@ export interface AddUrlHistoryOptions {
   fileName?: string
   imageBlob?: Blob
   thumbnailUrl?: string
+  pexelsSearchContext?: PexelsLastSearch
 }
 
 /**
@@ -51,13 +53,16 @@ export async function addUrlHistory(
   let finalFileName = opts.fileName
   let finalBlob = opts.imageBlob
   let finalThumbnailUrl = opts.thumbnailUrl
+  let finalSearchContext = opts.pexelsSearchContext
   // Only fall back to the stored thumbnailUrl for types that actually persist
   // it (currently just 'pexels'); for url/youtube the dropdown derives the
   // thumbnail at render time, so a lookup here would just cost a DB read.
   const needsThumbnailLookup = type === 'pexels' && !finalThumbnailUrl
+  const needsSearchContextLookup = type === 'pexels' && !finalSearchContext
   if (
     !finalTitle ||
     needsThumbnailLookup ||
+    needsSearchContextLookup ||
     (type === 'image' && (!finalFileName || !finalBlob))
   ) {
     const existing = await db.urlHistory.get(key)
@@ -65,6 +70,7 @@ export async function addUrlHistory(
     if (!finalFileName) finalFileName = existing?.fileName
     if (!finalBlob) finalBlob = existing?.imageBlob
     if (!finalThumbnailUrl) finalThumbnailUrl = existing?.thumbnailUrl
+    if (!finalSearchContext) finalSearchContext = existing?.pexelsSearchContext
   }
 
   const entry: UrlHistoryEntry = { url: key, type, lastUsedAt: new Date() }
@@ -72,6 +78,7 @@ export async function addUrlHistory(
   if (finalFileName) entry.fileName = finalFileName
   if (finalBlob) entry.imageBlob = finalBlob
   if (finalThumbnailUrl) entry.thumbnailUrl = finalThumbnailUrl
+  if (finalSearchContext) entry.pexelsSearchContext = finalSearchContext
   await db.urlHistory.put(entry)
 
   const all = await db.urlHistory.toArray()

--- a/src/utils/pexels.ts
+++ b/src/utils/pexels.ts
@@ -2,6 +2,15 @@ import type { ReferenceInfo } from '../types'
 
 const PEXELS_API_BASE = 'https://api.pexels.com/v1'
 const API_KEY_STORAGE_KEY = 'pexelsApiKey'
+const LAST_SEARCH_STORAGE_KEY = 'pexels.lastSearch'
+
+export type PexelsOrientationFilter = 'all' | 'landscape' | 'portrait' | 'square'
+const ORIENTATION_FILTERS: readonly PexelsOrientationFilter[] = ['all', 'landscape', 'portrait', 'square']
+
+export interface PexelsLastSearch {
+  query: string
+  orientation: PexelsOrientationFilter
+}
 
 export interface PexelsPhotoSrc {
   original: string
@@ -88,6 +97,29 @@ export function setPexelsApiKey(key: string): void {
     } else {
       localStorage.setItem(API_KEY_STORAGE_KEY, key)
     }
+  } catch {
+    // localStorage disabled / unavailable
+  }
+}
+
+export function getPexelsLastSearch(): PexelsLastSearch | null {
+  try {
+    const raw = localStorage.getItem(LAST_SEARCH_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object') return null
+    const { query, orientation } = parsed as Record<string, unknown>
+    if (typeof query !== 'string' || typeof orientation !== 'string') return null
+    if (!ORIENTATION_FILTERS.includes(orientation as PexelsOrientationFilter)) return null
+    return { query, orientation: orientation as PexelsOrientationFilter }
+  } catch {
+    return null
+  }
+}
+
+export function setPexelsLastSearch(query: string, orientation: PexelsOrientationFilter): void {
+  try {
+    localStorage.setItem(LAST_SEARCH_STORAGE_KEY, JSON.stringify({ query, orientation }))
   } catch {
     // localStorage disabled / unavailable
   }


### PR DESCRIPTION
## Summary
- URL履歴から Pexels 写真を再度開いたときの「検索に戻る」が、その写真を最初に見つけた検索コンテキスト(キーワード+orientation)に戻るよう修正
- 写真選択時に現在の検索コンテキストを `urlHistory.pexelsSearchContext` フィールドに永続化(Dexie v7 を additive field アンカーとして bump、index は変更なし)
- URL履歴から Pexels 写真を読み込む際、エントリの保存済みコンテキストを取得して `PexelsSearcher` を `key` 更新で remount、`initialQuery` / `initialOrientation` で復元
- フォールバック: コンテキスト未保存(レガシーエントリ)や URL履歴経由でない通常表示の場合は、従来通り `localStorage['pexels.lastSearch']` の最新検索を復元

## Background
最初の実装は localStorage に「最後の検索」を1組だけ保存する設計だったため、A→A1選択 → B→B1選択 → URL履歴からA1を選択 → 検索に戻る、というフローでキーワードAではなくBが復元される問題があった。写真ごとに検索コンテキストを記録することで「その写真をどの検索で見つけたか」が個別に復元される。

## Files Changed
- `src/utils/pexels.ts` — `PexelsLastSearch` 型・`getPexelsLastSearch` / `setPexelsLastSearch` ヘルパー(API キー永続化と凝集)
- `src/storage/db.ts` — `UrlHistoryEntry.pexelsSearchContext` を追加、Dexie v7 で anchor
- `src/storage/urlHistoryStore.ts` — `AddUrlHistoryOptions.pexelsSearchContext` 追加 + フィールド保持セマンティクスに対応
- `src/components/PexelsSearcher.tsx` — `initialOrientation` prop 追加、`initialQuery`/`initialOrientation` を初期 state に反映、初回マウント時の自動再検索
- `src/components/ReferencePanel.tsx` — `pexelsRestore` state、写真選択時にコンテキストを保存、URL履歴読込時に remount

## Test plan
- [x] 通常フロー: 検索 → 写真選択 → 「検索に戻る」で前回の結果が見える
- [x] **本丸**: A検索→A1選択→x→B検索→B1選択→x→URL履歴からA1→検索に戻る → キーワードAが復元される
- [x] URL履歴からB1を開いた場合は キーワードB が復元される
- [ ] レガシーエントリ(コンテキスト未保存)を URL履歴から開いた場合は従来通りの localStorage の最新検索が表示される
- [ ] orientation も写真ごとに復元される
- [ ] APIキー未設定でリロード → 自動検索が走らずキー要求バナーのみ
- [x] `npm run lint` グリーン
- [x] `npm run test` グリーン (347 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)