### PR TITLE
chore(deps): bump koizuka/pr-preview-action to v1.1.1

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Cleanup PR Preview
-        uses: koizuka/pr-preview-action@942966838e8175992f5fa468d7f6a640479c3c85 # v1
+        uses: koizuka/pr-preview-action@b03654e20a3e1a9c84309ac9a864e6ba3c4d078b # v1.1.1
         with:
           action: cleanup
           base-url: https://koizuka.github.io/drawing-practice

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
         run: npm run build -- --base=/drawing-practice/pr/${{ github.event.pull_request.number }}/
 
       - name: Deploy PR Preview
-        uses: koizuka/pr-preview-action@942966838e8175992f5fa468d7f6a640479c3c85 # v1
+        uses: koizuka/pr-preview-action@b03654e20a3e1a9c84309ac9a864e6ba3c4d078b # v1.1.1
         with:
           action: deploy
           source-dir: dist


### PR DESCRIPTION
## Summary
- Bump `koizuka/pr-preview-action` from `v1` (`94296683…`) to `v1.1.1` (`b03654e2…`)
- v1.1.1 pins its internal `actions/github-script` to a full SHA (`3a2844b7…` v9.0.0), making the entire transitive dependency tree SHA-pinned
- Unblocks enabling the repo setting **"Require actions to be pinned to a full-length commit SHA"**

## Why
The SHA-pinning policy enforces transitive `uses:` inside composite actions. Before this change, `koizuka/pr-preview-action` v1 referenced `actions/github-script@v8` (tag, not SHA) internally, which would have caused the workflow to fail under that policy.

## Test plan
- [ ] CI workflow (`test.yml`) green — verifies the PR Preview job using v1.1.1 deploys successfully
- [ ] PR Preview comment is posted by the action
- [ ] After merge: confirm `pr-cleanup.yml` runs cleanly when this PR is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)