### PR TITLE
Prevent unintended text selection and page pinch-zoom on iPad/trackpad

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>Drawing Practice</title>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Drawing Practice</title>
   </head>
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -10,3 +10,18 @@ html, body, #root {
   overflow: hidden;
   touch-action: none;
 }
+
+body {
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
+  overscroll-behavior: none;
+}
+
+input,
+textarea,
+[contenteditable="true"] {
+  -webkit-user-select: text;
+  user-select: text;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,21 +3,24 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-// Page-zoom defenses for areas that don't host self-rolled pinch:
-// - iOS Safari: two-finger pinch fires `gesturestart`/`gesturechange`/`gestureend`
-//   independently of `touch-action: none` and `maximum-scale=1.0` in the viewport
-//   meta — large-area UI (Sketchfab/Pexels search grid, URL input screen) still
-//   pinch-zooms unless these gesture events are intercepted at the document level.
-// - Trackpad / Ctrl+wheel: browsers report pinch as `wheel` with `ctrlKey: true`.
+// Block trackpad / Ctrl+wheel page zoom. Browsers report trackpad pinch as
+// `wheel` with `ctrlKey: true`; otherwise the chrome and reference selection
+// screens silently page-zoom while the user means to pinch the canvas.
 // Self-rolled pinch (ImageViewer, YouTubeViewer, DrawingCanvas) keeps working —
-// it's built on TouchEvents plus per-canvas `wheel` listeners that still fire here.
-const preventGesture = (e: Event) => e.preventDefault()
-document.addEventListener('gesturestart', preventGesture)
-document.addEventListener('gesturechange', preventGesture)
-document.addEventListener('gestureend', preventGesture)
-document.addEventListener('wheel', (e) => {
+// each registers its own per-canvas `wheel` listener that still fires here.
+// iOS touch pinch and browser zoom (Cmd +/-, accessibility zoom) are intentionally
+// left available — viewport meta no longer locks scale, so users who need to zoom
+// can still do so.
+const preventCtrlWheelZoom = (e: WheelEvent) => {
   if (e.ctrlKey) e.preventDefault()
-}, { passive: false })
+}
+document.addEventListener('wheel', preventCtrlWheelZoom, { passive: false })
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    document.removeEventListener('wheel', preventCtrlWheelZoom)
+  })
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,20 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
+// Page-zoom defenses for areas that don't host self-rolled pinch:
+// - iOS Safari: two-finger pinch fires `gesturestart`/`gesturechange`/`gestureend`
+//   independently of `touch-action: none` and slips through on toolbars / search UI.
+// - Trackpad / Ctrl+wheel: browsers report pinch as `wheel` with `ctrlKey: true`.
+// Self-rolled pinch (ImageViewer, YouTubeViewer, DrawingCanvas) keeps working —
+// it's built on TouchEvents plus per-canvas `wheel` listeners that still fire here.
+const preventGesture = (e: Event) => e.preventDefault()
+document.addEventListener('gesturestart', preventGesture)
+document.addEventListener('gesturechange', preventGesture)
+document.addEventListener('gestureend', preventGesture)
+document.addEventListener('wheel', (e) => {
+  if (e.ctrlKey) e.preventDefault()
+}, { passive: false })
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,18 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-// Block trackpad / Ctrl+wheel page zoom on UI chrome. Browsers report trackpad
-// pinch as `wheel` with `ctrlKey: true`, and viewport meta cannot constrain it.
-// iOS touch pinch is handled declaratively by the viewport meta `maximum-scale=1.0`.
+// Page-zoom defenses for areas that don't host self-rolled pinch:
+// - iOS Safari: two-finger pinch fires `gesturestart`/`gesturechange`/`gestureend`
+//   independently of `touch-action: none` and `maximum-scale=1.0` in the viewport
+//   meta — large-area UI (Sketchfab/Pexels search grid, URL input screen) still
+//   pinch-zooms unless these gesture events are intercepted at the document level.
+// - Trackpad / Ctrl+wheel: browsers report pinch as `wheel` with `ctrlKey: true`.
 // Self-rolled pinch (ImageViewer, YouTubeViewer, DrawingCanvas) keeps working —
-// each registers its own per-canvas `wheel` listener that still fires here.
+// it's built on TouchEvents plus per-canvas `wheel` listeners that still fire here.
+const preventGesture = (e: Event) => e.preventDefault()
+document.addEventListener('gesturestart', preventGesture)
+document.addEventListener('gesturechange', preventGesture)
+document.addEventListener('gestureend', preventGesture)
 document.addEventListener('wheel', (e) => {
   if (e.ctrlKey) e.preventDefault()
 }, { passive: false })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,16 +3,11 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-// Page-zoom defenses for areas that don't host self-rolled pinch:
-// - iOS Safari: two-finger pinch fires `gesturestart`/`gesturechange`/`gestureend`
-//   independently of `touch-action: none` and slips through on toolbars / search UI.
-// - Trackpad / Ctrl+wheel: browsers report pinch as `wheel` with `ctrlKey: true`.
+// Block trackpad / Ctrl+wheel page zoom on UI chrome. Browsers report trackpad
+// pinch as `wheel` with `ctrlKey: true`, and viewport meta cannot constrain it.
+// iOS touch pinch is handled declaratively by the viewport meta `maximum-scale=1.0`.
 // Self-rolled pinch (ImageViewer, YouTubeViewer, DrawingCanvas) keeps working —
-// it's built on TouchEvents plus per-canvas `wheel` listeners that still fire here.
-const preventGesture = (e: Event) => e.preventDefault()
-document.addEventListener('gesturestart', preventGesture)
-document.addEventListener('gesturechange', preventGesture)
-document.addEventListener('gestureend', preventGesture)
+// each registers its own per-canvas `wheel` listener that still fires here.
 document.addEventListener('wheel', (e) => {
   if (e.ctrlKey) e.preventDefault()
 }, { passive: false })


### PR DESCRIPTION
## Summary

iPad + Apple Pencil で描画中、ツールバーのタイマー部分からキャンバス領域にかけて意図せずテキスト選択（青ハイライト）になる現象、および iPad/iPhone/macOS のトラックパッドで意図せずページがピンチズームされる現象への対策。

アクセシビリティを大きく損なわない範囲で防御する方針（option C）を採用。

## 最終構成

- **`src/index.css`** — `body` に `user-select: none` / `-webkit-touch-callout: none` / `-webkit-tap-highlight-color: transparent` / `overscroll-behavior: none` を追加。`input` / `textarea` / `[contenteditable]` だけ `user-select: text` で除外し、URL 入力・APIキー入力等の操作性は維持。
- **`index.html`** — viewport meta に `viewport-fit=cover` を追加（iPad のセーフエリア対応）。`maximum-scale` / `user-scalable` のロックは accessibility のため**入れない**。
- **`src/main.tsx`** — document に `wheel` イベントの `ctrlKey: true` を `preventDefault`（macOS/iPadOS トラックパッドのページズーム抑制）。Vite HMR で listener が重複しないよう `import.meta.hot.dispose` で cleanup を登録。

## 防御範囲とトレードオフ

| 操作 | 挙動 |
|---|---|
| iPad/iPhone Apple Pencil でツールバーを擦る | テキスト選択されない (`user-select: none`) |
| トラックパッドで UI をピンチ | ページズームしない (`wheel.ctrlKey` 抑止) |
| iPad の指 2 本でツールバーをピンチ | IconButton の構造的に偶発ピンチが起きにくい |
| iPad の指 2 本で Reference 選択画面（検索グリッド・URL入力）をピンチ | **ピンチズーム可能**（accessibility 確保のため意図的） |
| 自前ピンチズーム (ImageViewer / YouTubeViewer / DrawingCanvas) | 引き続き動作 |
| Sketchfab 3D モデル操作 (iframe 内) | 引き続き動作 |
| ブラウザのアクセシビリティズーム (Cmd +/-, ロービジョン向け拡大) | 引き続き動作 |

## Self-rolled pinch への非影響

`ImageViewer` / `YouTubeViewer` / `DrawingCanvas` のピンチは React `TouchEvent` + canvas 個別の `addEventListener('wheel', ..., { passive: false })` で実装されており、document の `preventDefault` を経由しても JS ハンドラ自体は通常通り発火するため自前ピンチは継続動作する。Sketchfab の 3D 操作は iframe 内で完結しており document リスナは到達しない。

## 設計判断の経緯

実機で 2 案を比較検証した:

1. **多重抑止案**（commit 1, 3）: `gesturestart` 系 document 抑止 + viewport `maximum-scale=1.0` + `wheel.ctrlKey` 抑止
   - 全領域で完全防御
   - Copilot レビューで「viewport scale ロックはロービジョンユーザのピンチズーム/ブラウザズームを奪う重大な accessibility リグレッション」と指摘
2. **viewport meta のみ案**（commit 2）: viewport `maximum-scale=1.0` + `wheel.ctrlKey` 抑止
   - 実機検証で iOS Safari は `maximum-scale=1.0` を「大きな領域」（Sketchfab/Pexels 検索グリッド、URL 入力画面など）に対して律儀に適用しない挙動を確認 — 結局検索画面は普通にピンチズーム可能
   - viewport ロックの accessibility リグレッションは残るのに、防御は不完全

→ どちらも accessibility と完全防御を両立できないため、**accessibility を優先**する option C を採用（commit 4）。トラックパッドの誤ピンチは描画体験に直接響くので `wheel.ctrlKey` 抑止だけは残し、iOS の指ピンチによるページ拡大は ユーザの自由に委ねる構成。

## Commit 構成

squash merge 推奨。

1. `fix: prevent unintended text selection and page pinch-zoom on iPad/trackpad` — 多重抑止の初期実装
2. `refactor: drop iOS gesturestart suppression in favor of viewport meta` — 検証用の簡略化
3. `fix: restore iOS gesturestart suppression — viewport meta alone misses search UI` — 検証結果に基づく多重抑止復活
4. `refactor: drop pinch-zoom lock to preserve accessibility (option C)` — Copilot 指摘を受けて accessibility 優先構成へ + HMR cleanup

## Test plan

- [x] iPad + Apple Pencil: タイマー・ツールバーをペン先で擦っても青ハイライトが出ない
- [x] iPad: ツールバー・Reference 選択画面で Apple Pencil で偶発的に意図しないテキスト選択が起きない
- [x] iPhone: 同上
- [x] macOS トラックパッド: UI 上でピンチしてもページがズームしない
- [x] iPad の指 2 本でブラウザのピンチズームが（accessibility のため）使えること
- [x] iPad: 画像ビューア・キャンバス上の自前ピンチズームは引き続き動く
- [x] iPad: Sketchfab 3D モデルの回転/ズーム/パンは引き続き動く
- [x] TextField (URL 入力、APIキー入力、Pexels 検索) でテキストの選択・コピー・ペーストが動く
- [ ] iPhone / macOS: 既存の操作に回帰なし（描画、ギャラリー、検索、URL 入力）

🤖 Generated with [Claude Code](https://claude.com/claude-code)