### PR TITLE
fix: persist reference changes immediately to survive fast reloads

### DIFF
--- a/.claude/rules/timer-autosave.md
+++ b/.claude/rules/timer-autosave.md
@@ -36,7 +36,7 @@ Reference-related pausing is wired through `pauseAndIncrementVersion` in `SplitL
 - Tracks changes via a version counter incremented by state setters in `SplitLayout`.
 - **Suppressed during draft restore** to avoid overwriting with partial state.
 - Clears draft when session is empty (no strokes and no reference).
-- **Immediate-save path** for reference changes: `useAutosave` takes a separate `flushVersion` prop. `changeReference`, `resetReferenceOnError`, and the reference snapshot restorer (undo/redo) bump it via `incrementFlushVersion`. The hook observes the bump in a useEffect (so React has already committed the setState updates), cancels any pending debounce timer, and runs `saveDraft` synchronously. **Why:** a reload immediately after a reference swap would otherwise restore the previous reference. Stroke and guide changes still go through the 2s debounce path.
+- **Immediate-save path** for reference changes: `useAutosave` takes a separate `flushVersion` prop. `changeReference`, `resetReferenceOnError`, and the reference snapshot restorer (undo/redo) bump it via `incrementFlushVersion`. The hook observes the bump in a useEffect (so React has already committed the setState updates), cancels any pending debounce timer, and queues `saveDraft` immediately (no debounce — the IndexedDB write itself is still async). **Why:** a reload immediately after a reference swap would otherwise restore the previous reference. Stroke and guide changes still go through the 2s debounce path.
 
 Persisted: strokes, redo stack, reference, guides, timer elapsed.
 **NOT persisted**: reference undo history (kept session-only — see `drawing-undo.md`).

--- a/.claude/rules/timer-autosave.md
+++ b/.claude/rules/timer-autosave.md
@@ -36,6 +36,7 @@ Reference-related pausing is wired through `pauseAndIncrementVersion` in `SplitL
 - Tracks changes via a version counter incremented by state setters in `SplitLayout`.
 - **Suppressed during draft restore** to avoid overwriting with partial state.
 - Clears draft when session is empty (no strokes and no reference).
+- **Immediate-save path** for reference changes: `useAutosave` takes a separate `flushVersion` prop. `changeReference`, `resetReferenceOnError`, and the reference snapshot restorer (undo/redo) bump it via `incrementFlushVersion`. The hook observes the bump in a useEffect (so React has already committed the setState updates), cancels any pending debounce timer, and runs `saveDraft` synchronously. **Why:** a reload immediately after a reference swap would otherwise restore the previous reference. Stroke and guide changes still go through the 2s debounce path.
 
 Persisted: strokes, redo stack, reference, guides, timer elapsed.
 **NOT persisted**: reference undo history (kept session-only — see `drawing-undo.md`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Vite + React + TypeScript (strict mode), Material-UI, Vitest + React Testing Lib
   - **Drawing Panel** (right/bottom) — `DrawingPanel` + `DrawingCanvas`.
 - **Shared state** lifted to `SplitLayout`: reference (source/mode/images), timer, autosave, undo. Guide state shared via `GuideContext`.
 - **Single undo stack** in `StrokeManager` covers both strokes AND reference changes — see `.claude/rules/drawing-undo.md`.
-- **Autosave** (`useAutosave`, 2s debounce) persists session draft to IndexedDB `session` table; restored on reload — see `.claude/rules/timer-autosave.md`.
+- **Autosave** (`useAutosave`, 2s debounce; immediate on reference change) persists session draft to IndexedDB `session` table; restored on reload — see `.claude/rules/timer-autosave.md`.
 
 ## Cross-cutting invariants
 

--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -106,8 +106,9 @@ function SplitLayoutInner() {
   // Change version counter for autosave debouncing
   const [changeVersion, setChangeVersion] = useState(0)
   // Flush version: bumped on reference changes to bypass the 2s debounce and
-  // persist the draft synchronously (so a fast reload after a reference swap
-  // doesn't restore the previous reference).
+  // queue saveDraft immediately (so a fast reload after a reference swap
+  // doesn't restore the previous reference). The IndexedDB write is still
+  // async but starts right away.
   const [flushVersion, setFlushVersion] = useState(0)
   // Restore version to notify DrawingPanel after draft restore
   const [restoreVersion, setRestoreVersion] = useState(0)

--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -105,6 +105,10 @@ function SplitLayoutInner() {
 
   // Change version counter for autosave debouncing
   const [changeVersion, setChangeVersion] = useState(0)
+  // Flush version: bumped on reference changes to bypass the 2s debounce and
+  // persist the draft synchronously (so a fast reload after a reference swap
+  // doesn't restore the previous reference).
+  const [flushVersion, setFlushVersion] = useState(0)
   // Restore version to notify DrawingPanel after draft restore
   const [restoreVersion, setRestoreVersion] = useState(0)
   // Explicit refit trigger on rotation — ResizeObservers don't auto-refit so
@@ -124,6 +128,10 @@ function SplitLayoutInner() {
   const [historySyncVersion, setHistorySyncVersion] = useState(0)
   const incrementChangeVersion = useCallback(() => {
     setChangeVersion(v => v + 1)
+  }, [])
+
+  const incrementFlushVersion = useCallback(() => {
+    setFlushVersion(v => v + 1)
   }, [])
 
   // Pause timer whenever the reference changes — the timer should only advance
@@ -163,6 +171,7 @@ function SplitLayoutInner() {
       setLocalImageUrl(snap.localImageUrl)
       setReferenceInfo(snap.referenceInfo)
       pauseAndIncrementVersion()
+      incrementFlushVersion()
     }
   })
 
@@ -184,7 +193,8 @@ function SplitLayoutInner() {
     })
     pauseAndIncrementVersion()
     setHistorySyncVersion(v => v + 1)
-  }, [captureReferenceSnapshot, pauseAndIncrementVersion])
+    incrementFlushVersion()
+  }, [captureReferenceSnapshot, pauseAndIncrementVersion, incrementFlushVersion])
 
   /**
    * Error-path reset. NOT recorded as an undoable entry — undoing back to a
@@ -199,7 +209,8 @@ function SplitLayoutInner() {
     setLocalImageUrl(null)
     setReferenceInfo(null)
     pauseAndIncrementVersion()
-  }, [pauseAndIncrementVersion])
+    incrementFlushVersion()
+  }, [pauseAndIncrementVersion, incrementFlushVersion])
 
   const handleReferenceImageSize = useCallback((width: number, height: number) => {
     setReferenceSize({ width, height })
@@ -389,7 +400,7 @@ function SplitLayoutInner() {
     lines,
   }), [source, referenceInfo, localImageUrl, fixedImageUrl, grid, lines])
 
-  useAutosave(getAutosaveState, changeVersion, suppressAutosaveRef)
+  useAutosave(getAutosaveState, changeVersion, flushVersion, suppressAutosaveRef)
 
   // Trigger autosave when guide state changes. Use the render-time prev-prop
   // pattern instead of an effect so we don't violate react-hooks/set-state-in-effect.

--- a/src/hooks/useAutosave.test.ts
+++ b/src/hooks/useAutosave.test.ts
@@ -33,7 +33,7 @@ describe('useAutosave', () => {
 
   it('does not save on initial render (changeVersion=0)', () => {
     const suppressRef = { current: false }
-    renderHook(() => useAutosave(() => makeState(), 0, suppressRef))
+    renderHook(() => useAutosave(() => makeState(), 0, 0, suppressRef))
 
     vi.advanceTimersByTime(3000)
     expect(saveDraft).not.toHaveBeenCalled()
@@ -42,7 +42,7 @@ describe('useAutosave', () => {
   it('saves after debounce delay when changeVersion > 0', async () => {
     const suppressRef = { current: false }
     const { rerender } = renderHook(
-      ({ version }) => useAutosave(() => makeState(), version, suppressRef),
+      ({ version }) => useAutosave(() => makeState(), version, 0, suppressRef),
       { initialProps: { version: 0 } },
     )
 
@@ -62,7 +62,7 @@ describe('useAutosave', () => {
   it('debounces rapid changes', async () => {
     const suppressRef = { current: false }
     const { rerender } = renderHook(
-      ({ version }) => useAutosave(() => makeState(), version, suppressRef),
+      ({ version }) => useAutosave(() => makeState(), version, 0, suppressRef),
       { initialProps: { version: 0 } },
     )
 
@@ -85,7 +85,7 @@ describe('useAutosave', () => {
   it('clears draft when no strokes and no reference', async () => {
     const suppressRef = { current: false }
     const { rerender } = renderHook(
-      ({ version }) => useAutosave(() => makeState({ strokes: [], source: 'none' }), version, suppressRef),
+      ({ version }) => useAutosave(() => makeState({ strokes: [], source: 'none' }), version, 0, suppressRef),
       { initialProps: { version: 0 } },
     )
 
@@ -101,7 +101,7 @@ describe('useAutosave', () => {
   it('does not save when suppressed', async () => {
     const suppressRef = { current: true }
     const { rerender } = renderHook(
-      ({ version }) => useAutosave(() => makeState(), version, suppressRef),
+      ({ version }) => useAutosave(() => makeState(), version, 0, suppressRef),
       { initialProps: { version: 0 } },
     )
 
@@ -112,5 +112,81 @@ describe('useAutosave', () => {
 
     expect(saveDraft).not.toHaveBeenCalled()
     expect(clearDraft).not.toHaveBeenCalled()
+  })
+
+  it('flushes immediately when flushVersion changes', async () => {
+    const suppressRef = { current: false }
+    const { rerender } = renderHook(
+      ({ flush }) => useAutosave(() => makeState(), 0, flush, suppressRef),
+      { initialProps: { flush: 0 } },
+    )
+
+    await act(async () => {
+      rerender({ flush: 1 })
+    })
+
+    // Saved without advancing the debounce timer.
+    expect(saveDraft).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels pending debounce when flushVersion fires', async () => {
+    const suppressRef = { current: false }
+    const { rerender } = renderHook(
+      ({ version, flush }) => useAutosave(() => makeState(), version, flush, suppressRef),
+      { initialProps: { version: 0, flush: 0 } },
+    )
+
+    // Schedule a debounced save, then before it fires bump flushVersion.
+    rerender({ version: 1, flush: 0 })
+    vi.advanceTimersByTime(1000)
+
+    await act(async () => {
+      rerender({ version: 1, flush: 1 })
+    })
+
+    // Immediate save fired once.
+    expect(saveDraft).toHaveBeenCalledTimes(1)
+
+    // Past the original debounce: still only one save (pending timer was cancelled).
+    await act(async () => {
+      vi.advanceTimersByTime(2100)
+    })
+    expect(saveDraft).toHaveBeenCalledTimes(1)
+  })
+
+  it('respects suppressRef on immediate flush', async () => {
+    const suppressRef = { current: true }
+    const { rerender } = renderHook(
+      ({ flush }) => useAutosave(() => makeState(), 0, flush, suppressRef),
+      { initialProps: { flush: 0 } },
+    )
+
+    await act(async () => {
+      rerender({ flush: 1 })
+    })
+
+    expect(saveDraft).not.toHaveBeenCalled()
+    expect(clearDraft).not.toHaveBeenCalled()
+  })
+
+  it('uses latest state on flush (no stale capture)', async () => {
+    const suppressRef = { current: false }
+    let currentState = makeState({ referenceInfo: { title: 'Old', author: 'A', source: 'sketchfab' as const, sketchfabUid: 'old' } })
+    const { rerender } = renderHook(
+      ({ flush }) => useAutosave(() => currentState, 0, flush, suppressRef),
+      { initialProps: { flush: 0 } },
+    )
+
+    // Update state, then bump flushVersion. The hook captures getState via ref,
+    // so the latest reference data should make it into saveDraft.
+    currentState = makeState({ referenceInfo: { title: 'New', author: 'B', source: 'sketchfab' as const, sketchfabUid: 'new' } })
+
+    await act(async () => {
+      rerender({ flush: 1 })
+    })
+
+    expect(saveDraft).toHaveBeenCalledTimes(1)
+    const arg = (saveDraft as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(arg.referenceInfo).toMatchObject({ title: 'New', sketchfabUid: 'new' })
   })
 })

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -75,9 +75,10 @@ export function useAutosave(
     }
   }, [changeVersion, doSave])
 
-  // Immediate-save path. Reference changes bump flushVersion so the draft is
-  // persisted synchronously instead of waiting for the 2s debounce — otherwise
-  // a quick reload after a reference swap would restore the previous reference.
+  // Immediate-save path. Reference changes bump flushVersion so saveDraft fires
+  // immediately (without waiting for the 2s debounce). The IndexedDB write
+  // itself is async, but the call is queued right away — otherwise a quick
+  // reload after a reference swap would restore the previous reference.
   useEffect(() => {
     if (flushVersion === 0) return // Skip initial render
 

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -21,6 +21,7 @@ interface AutosaveState {
 export function useAutosave(
   getState: () => AutosaveState,
   changeVersion: number,
+  flushVersion: number,
   suppressRef: React.RefObject<boolean>,
 ) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -73,4 +74,17 @@ export function useAutosave(
       }
     }
   }, [changeVersion, doSave])
+
+  // Immediate-save path. Reference changes bump flushVersion so the draft is
+  // persisted synchronously instead of waiting for the 2s debounce — otherwise
+  // a quick reload after a reference swap would restore the previous reference.
+  useEffect(() => {
+    if (flushVersion === 0) return // Skip initial render
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    doSave()
+  }, [flushVersion, doSave])
 }


### PR DESCRIPTION
## Summary

- 参照（Sketchfab / 画像 / YouTube / Pexels）切り替え直後にリロードすると、前の参照に戻ってしまう問題を修正
- `useAutosave` に `flushVersion` 引数を追加し、参照変更（`changeReference` / `resetReferenceOnError` / undo・redo の reference snapshot 復元）では 2 秒 debounce をバイパスして即時 `saveDraft` を実行
- ストローク・ガイドの 2 秒 debounce 動作は維持（I/O 増加なし）
- `CLAUDE.md` と `.claude/rules/timer-autosave.md` を新仕様に合わせて更新

## なぜこの設計か

`useAutosave` に imperative な `flush()` 関数を expose して `changeReference` 内で直接呼ぶと、`setSource` 等の `setState` がまだコミットされていないため `getStateRef.current()` が古い値を返してしまう。`flushVersion` を bump → `useEffect` で観測 → `doSave()` の流れにすれば、effect 実行時点で React が setState をコミット済みなので最新 reference が確実に保存される（既存 `changeVersion` debounce path と同じ仕組み）。

## Test plan

- [x] `npm run lint` 緑
- [x] `npm run build` 成功
- [x] `npm run test` 緑（370 passed / 24 files）。`useAutosave` に新規テスト 4 件追加:
  - flushVersion 変化で即時保存される
  - pending debounce が flushVersion 発火時にキャンセルされる
  - `suppressRef` は immediate flush でも尊重される
  - flush 時に最新 state（stale でない）が保存される
- [ ] 実機（iPad Safari 想定）で確認:
  - [ ] 画像 URL を読み込む → 即リロード → 同じ画像が復元される
  - [x] Sketchfab Fix Angle → 即リロード → 固定スクショ復元
  - [x] Pexels で写真選択 → 即リロード → 同写真復元
  - [ ] YouTube URL を貼る → 即リロード → 同 URL 復元
  - [x] Close ボタンで参照を閉じる → 即リロード → 何も復元されない
  - [ ] 壊れた画像 URL 貼付（`resetReferenceOnError`）→ 即リロード → 何も復元されない（ループ防止）
  - [x] ストローク追加直後（2 秒以内）リロード → 未保存（既存挙動のまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)