### PR TITLE
feat: add Sketchfab model link to reference info overlay

### DIFF
--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -178,7 +178,7 @@ function ReferenceInfoOverlay({ refInfo }: { refInfo: ReferenceInfo }) {
                 {refInfo.title}
               </Typography>
             )}
-            {refInfo.author && (
+            {(refInfo.author || (refInfo.source === 'sketchfab' && refInfo.sketchfabUid)) && (
               <Typography variant="caption" sx={{ display: 'block', opacity: 0.9, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                 {refInfo.source === 'pexels' && refInfo.pexelsPhotographerUrl ? (
                   <>
@@ -194,6 +194,14 @@ function ReferenceInfoOverlay({ refInfo }: { refInfo: ReferenceInfo }) {
                         </MuiLink>
                       </>
                     )}
+                  </>
+                ) : refInfo.source === 'sketchfab' && refInfo.sketchfabUid ? (
+                  <>
+                    {refInfo.author}
+                    {refInfo.author && ' · '}
+                    <MuiLink href={canonicalSketchfabUrl(refInfo.sketchfabUid)} target="_blank" rel="noopener noreferrer" sx={{ color: 'inherit', textDecoration: 'underline' }}>
+                      {t('sketchfabViaSketchfab')}
+                    </MuiLink>
                   </>
                 ) : refInfo.author}
               </Typography>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -61,6 +61,7 @@ const messages = {
     'technology': 'Technology',
     'allCategories': 'All',
     'sketchfabSearchHistoryDelete': 'Delete from history',
+    'sketchfabViaSketchfab': 'via Sketchfab',
 
     // Gallery
     'galleryTitle': 'Gallery',
@@ -189,6 +190,7 @@ const messages = {
     'technology': 'テクノロジー',
     'allCategories': '全カテゴリ',
     'sketchfabSearchHistoryDelete': '履歴から削除',
+    'sketchfabViaSketchfab': 'Sketchfabで開く',
 
     // Gallery
     'galleryTitle': 'ギャラリー',


### PR DESCRIPTION
## Summary

- Mirror the Pexels "via Pexels" link affordance for Sketchfab so the model URL is clickable and copyable from the reference info pill that appears on the fixed reference image.
- Previously the UID was buried in IndexedDB only — looking it up to retest a model required digging through DevTools. Now right-click → copy link gives the canonical `https://sketchfab.com/models/<uid>` URL.
- The author line renders `<author> · via Sketchfab` when `sketchfabUid` is present; falls back to just `via Sketchfab` when the author hasn't been resolved (URL paste before the Data API metadata fetch lands, or legacy gallery records without author).
- Adds the `sketchfabViaSketchfab` i18n key (en: `via Sketchfab`, ja: `Sketchfabで開く`).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test` — 370 passed
- [x] `npm run build` — succeeds
- [x] Manual: After Fix Angle on a Sketchfab model, the reference info pill shows `<author> · via Sketchfab`, the link opens the model page in a new tab, and right-click copies the URL
- [x] Manual: Pexels reference info pill is unchanged (still shows `Photo by <author> · via Pexels`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)