### PR TITLE
refactor(ui): codify design principles and harden search viewer UX

### DIFF
--- a/.claude/rules/ui-design-principles.md
+++ b/.claude/rules/ui-design-principles.md
@@ -1,0 +1,81 @@
+---
+paths:
+  - "src/components/**"
+---
+
+# UI design principles
+
+These principles are the basis for layout and component-choice decisions across `src/components/**`. They were extracted from the existing patterns in the codebase (Drawing/Reference panels, Sketchfab/Pexels/YouTube/Image viewers, Gallery) so future work can stay consistent.
+
+When a new UI is added or an existing one is changed, check it against these principles. If a deliberate deviation is needed, record the reason inline near the code so the next reader understands why.
+
+## 1. Layout skeleton
+
+- The full screen is the **two-panel `SplitLayout`** (Reference / Drawing). Each panel is a vertical flex container: **40px-high top toolbar + content area below**. The viewport uses `100dvh` (required for iPad Safari's dynamic toolbar).
+- Toolbar shape: `display: 'flex', height: 40, alignItems: 'center', gap, borderBottom`. Order from left to right:
+  1. Close / title
+  2. Function-button group(s), separated by 1px vertical dividers (`Box sx={{ width: '1px', height: 24, bgcolor: '#ddd' }}`)
+  3. `flex: 1` spacer
+  4. View / navigation button group (grid, flip, zoom-reset, fullscreen, gallery, etc.)
+
+## 2. The three-tier button model
+
+| Tier | Use | Component | Style |
+|---|---|---|---|
+| Toolbar action | In-panel mode/view controls | `IconButton size="small"` wrapped in `ToolbarTooltip` | Icon only. Active=`primary.main`, destructive=`error.main`, warning=`warning.main`, info=`info.main` |
+| Primary action | "Execute" buttons inside content (Search, Load More) | `Button size="small" variant="contained"` (or `"outlined"` for secondary) | Text + optional icon |
+| Source / navigation | Reference-empty source picker | `Button fullWidth` with icon and left-aligned label | Stacked vertically, identical styling |
+
+Always wrap toolbar `IconButton`s in `ToolbarTooltip` — never bare `Tooltip`. The wrapper handles touch-device behavior consistently.
+
+## 3. Stateful selection vs stateless shortcut (important)
+
+This is the rule that resolves "should this be a `Button` or a `Chip`?".
+
+- **Stateful** (the chosen value is held in state and visible in the UI; selection is exclusive):
+  - 2–4 mutually exclusive filters → `ToggleButtonGroup size="small"` (e.g. Sketchfab time filter, Pexels orientation filter, Gallery sort mode)
+  - 5+ exclusive filters with dynamic count → row of `Button variant="contained" / "outlined"` (active = `contained`). **Always provide an "All" / escape-hatch button** so users can clear the active selection (see Sketchfab Categories `handleClearCategory`).
+- **Stateless** (click executes an action and the button doesn't track selection):
+  - Quick-search presets, related-term suggestions → `Chip size="small" variant="outlined"` (e.g. Pexels Suggested chips)
+
+Same visual element, different roles → use different components. Same role across viewers → use the same component.
+
+## 4. Dialog / overlay / inline confirmation
+
+- **Inline (default)**: ordinary controls live inside the panel.
+- **Modal** (`position: 'fixed'`, z-index 1000): only for UI that **interrupts the workflow / replaces the screen** (currently Gallery, Settings, ApiKey dialog).
+- **Transient confirmation** (delete confirm, etc.): do NOT open a modal. Replace the relevant button group in the toolbar in-place (see DrawingPanel's Save/Gallery ↔ Delete/Cancel pattern). Keeps the user's spatial context.
+
+## 5. Error / notification severity mapping
+
+| Situation | Treatment |
+|---|---|
+| Configuration blocker requiring user action (API key missing, etc.) | `Alert severity="info"` with an action button |
+| Recoverable runtime error (search failed, image failed to load) | `Alert severity="error"` |
+| In progress | `CircularProgress` centered with `display: 'flex', justifyContent: 'center', my: 2`. For full-region overlays (e.g. iframe loading), use `position: 'absolute', inset: 0` with a translucent background |
+| Lightweight transient status (script/API still warming up) | `Typography variant="body2" color="text.secondary"` is acceptable |
+
+## 6. Autocomplete + history-dropdown convention
+
+- Use `Autocomplete` with `freeSolo`, `size="small"`, and **`openOnFocus` enabled by default**. Discoverability of past searches matters.
+- Each row: `<query text> / optional metadata Chip / Trash2 IconButton (delete)`, gap 8.
+- The delete `IconButton` must call `stopPropagation` on **both** `onPointerDown` and `onClick` — touch devices commit option selection on `pointerdown` before `click` fires.
+- Enter submits if the query is non-empty; empty query is a no-op.
+
+## 7. Result grid
+
+- `display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(N, 1fr))', gap: 1`.
+- Card: `border: '1px solid #ddd', borderRadius: 1, overflow: 'hidden'`, hover `borderColor: 'primary.main'`, `cursor: 'pointer'`.
+- `N` (min column width) is allowed to vary by content type — Sketchfab thumbs use 120px, Pexels photos use 160px. Don't unify these unless there's a reason.
+
+## 8. Access symmetry — when to add an entry point on both panels
+
+When you add a major operation, consciously decide whether it should be reachable from both panels.
+
+The current asymmetries are **deliberate role separations**, not oversights:
+
+- **Gallery entry exists only in DrawingPanel** — the drawing side owns the user's session output, so navigating to "previously saved drawings" belongs there.
+- **Guide-line operations exist only in ReferencePanel** — guides are anchored to the reference's coordinate space.
+- **"Use this reference" exists only inside Gallery** — it's a navigation choice from a record, not a panel-resident operation.
+
+Follow this rule for new additions: if an operation conceptually belongs to one side's role, do not duplicate it on the other side.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,3 +54,4 @@ Path-scoped rules in `.claude/rules/` load automatically when you read matching 
 - `reference-sources.md` — reference panel + viewers + utils (URL auto-routing, Sketchfab Fix-Angle triple persistence, YouTube overlay modes, Pexels attribution)
 - `timer-autosave.md` — `useTimer.ts`, `useAutosave.ts`, `SplitLayout.tsx` (start/pause/reset triggers, autosave debounce/suppression)
 - `gallery.md` — `Gallery.tsx`, `exportDrawing.ts`, `storageUsage.ts` (3 grouping modes, thumbnail resolution, "Use this reference" paths, export)
+- `ui-design-principles.md` — `src/components/**` (layout skeleton, three-tier button model, stateful vs stateless choice, error/loading treatment, access symmetry)

--- a/src/components/PexelsSearcher.test.tsx
+++ b/src/components/PexelsSearcher.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { PexelsSearchHistoryEntry } from '../storage/db'
+
+const getPexelsSearchHistoryMock = vi.fn<() => Promise<PexelsSearchHistoryEntry[]>>()
+const addPexelsSearchHistoryMock = vi.fn().mockResolvedValue(undefined)
+const deletePexelsSearchHistoryMock = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../storage', () => ({
+  getPexelsSearchHistory: () => getPexelsSearchHistoryMock(),
+  addPexelsSearchHistory: (...args: unknown[]) => addPexelsSearchHistoryMock(...args),
+  deletePexelsSearchHistory: (...args: unknown[]) => deletePexelsSearchHistoryMock(...args),
+}))
+
+import { PexelsSearcher } from './PexelsSearcher'
+
+const NOW = new Date()
+
+function makeEntry(overrides: Partial<PexelsSearchHistoryEntry> = {}): PexelsSearchHistoryEntry {
+  return {
+    key: 'pose',
+    query: 'pose',
+    orientation: 'all',
+    lastUsedAt: NOW,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  getPexelsSearchHistoryMock.mockReset().mockResolvedValue([])
+  addPexelsSearchHistoryMock.mockReset().mockResolvedValue(undefined)
+  deletePexelsSearchHistoryMock.mockReset().mockResolvedValue(undefined)
+  // Set a non-empty API key so the "needs key" banner doesn't disable input.
+  localStorage.setItem('pexelsApiKey', 'test-key')
+  localStorage.removeItem('pexelsLastSearch')
+})
+
+afterEach(() => {
+  localStorage.removeItem('pexelsApiKey')
+  localStorage.removeItem('pexelsLastSearch')
+})
+
+describe('PexelsSearcher history dropdown', () => {
+  it('opens the dropdown on focus thanks to openOnFocus, listing past queries', async () => {
+    getPexelsSearchHistoryMock.mockResolvedValue([
+      makeEntry({ key: 'pose', query: 'pose' }),
+      makeEntry({ key: 'figure', query: 'figure' }),
+    ])
+    render(<PexelsSearcher onSelectPhoto={vi.fn()} onOpenApiKeySettings={vi.fn()} />)
+
+    await waitFor(() => expect(getPexelsSearchHistoryMock).toHaveBeenCalled())
+
+    // The placeholder text is the localized search-input prompt — match by role
+    // and aria attributes via the textbox role to avoid coupling to the string.
+    const input = screen.getByRole('combobox')
+    fireEvent.mouseDown(input)
+    fireEvent.focus(input)
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: /pose/ })).toBeInTheDocument()
+    })
+    expect(screen.getByRole('option', { name: /figure/ })).toBeInTheDocument()
+  })
+})
+
+describe('PexelsSearcher search error feedback', () => {
+  it('shows an error Alert when the search fetch fails', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockRejectedValue(new TypeError('Network down'))
+
+    render(<PexelsSearcher onSelectPhoto={vi.fn()} onOpenApiKeySettings={vi.fn()} />)
+    await waitFor(() => expect(getPexelsSearchHistoryMock).toHaveBeenCalled())
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'pose' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    const alert = await screen.findByRole('alert')
+    // pexelsNetworkError content; matching loosely so locale changes don't break.
+    expect(alert.textContent).toBeTruthy()
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    fetchSpy.mockRestore()
+  })
+
+  it('does not surface an Alert when fetch succeeds', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ photos: [], next_page: null }), { status: 200 }),
+    )
+
+    render(<PexelsSearcher onSelectPhoto={vi.fn()} onOpenApiKeySettings={vi.fn()} />)
+    await waitFor(() => expect(getPexelsSearchHistoryMock).toHaveBeenCalled())
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'pose' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled())
+    // Wait one more tick for the success branch to run, then assert no error Alert.
+    await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
+    // The needsKey info Alert is gated on missing key — with a key set it should
+    // not be present, so any role="alert" here would be the error banner.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    fetchSpy.mockRestore()
+  })
+})

--- a/src/components/PexelsSearcher.tsx
+++ b/src/components/PexelsSearcher.tsx
@@ -225,6 +225,7 @@ export function PexelsSearcher({ onSelectPhoto, onOpenApiKeySettings, initialQue
       <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
         <Autocomplete<PexelsSearchHistoryEntry, false, false, true>
           freeSolo
+          openOnFocus
           size="small"
           sx={{ flex: 1 }}
           fullWidth
@@ -323,7 +324,7 @@ export function PexelsSearcher({ onSelectPhoto, onOpenApiKeySettings, initialQue
       </Box>
 
       {error && (
-        <Typography variant="body2" color="error" sx={{ mb: 1 }}>{error}</Typography>
+        <Alert severity="error" sx={{ mb: 1 }}>{error}</Alert>
       )}
 
       {loading && (

--- a/src/components/SketchfabViewer.test.tsx
+++ b/src/components/SketchfabViewer.test.tsx
@@ -360,6 +360,75 @@ describe('SketchfabViewer search loading and error feedback', () => {
     fetchSpy.mockRestore()
   })
 
+  it('clears a previous error when a category browse starts', async () => {
+    getSketchfabSearchHistoryMock.mockResolvedValue([])
+    // First call rejects (produces an error), second call resolves cleanly.
+    const fetchSpy = vi.spyOn(window, 'fetch')
+      .mockRejectedValueOnce(new TypeError('Network down'))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ results: [], next: null })))
+
+    render(<SketchfabViewer onFixAngle={vi.fn()} />)
+    await waitFor(() => expect(getSketchfabSearchHistoryMock).toHaveBeenCalled())
+
+    // Trigger an error first
+    fireEvent.click(screen.getByRole('button', { name: 'Animals' }))
+    await screen.findByRole('alert')
+
+    // Now click Vehicles — the error Alert should disappear because the new
+    // fetch starts with cleared error state.
+    fireEvent.click(screen.getByRole('button', { name: 'Vehicles' }))
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument())
+    fetchSpy.mockRestore()
+  })
+
+  it('aborts a stale search when a newer one starts so the spinner reflects the latest request only', async () => {
+    getSketchfabSearchHistoryMock.mockResolvedValue([])
+    // Track abort signals so we can verify the first request is canceled.
+    const signals: AbortSignal[] = []
+    let resolveSecond: ((value: Response) => void) | undefined
+    const fetchSpy = vi.spyOn(window, 'fetch').mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.signal) signals.push(init.signal)
+        // First call: never resolves on its own; will be aborted.
+        if (signals.length === 1) {
+          return new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              reject(new DOMException('Aborted', 'AbortError'))
+            })
+          })
+        }
+        // Second call: resolves when test triggers it.
+        return new Promise<Response>(resolve => { resolveSecond = resolve })
+      },
+    )
+
+    render(<SketchfabViewer onFixAngle={vi.fn()} />)
+    await waitFor(() => expect(getSketchfabSearchHistoryMock).toHaveBeenCalled())
+
+    const input = screen.getByPlaceholderText('Search models or paste UID / URL...')
+    fireEvent.change(input, { target: { value: 'tree' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => expect(signals).toHaveLength(1))
+
+    // Start a second search while the first is still in flight.
+    fireEvent.change(input, { target: { value: 'castle' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => expect(signals).toHaveLength(2))
+
+    // First signal should now be aborted; second remains active.
+    expect(signals[0].aborted).toBe(true)
+    expect(signals[1].aborted).toBe(false)
+    // Spinner is still on (second request running).
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+    // No error from the aborted first request.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+    // Resolve the second request — spinner should clear.
+    resolveSecond?.(new Response(JSON.stringify({ results: [], next: null })))
+    await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
+    fetchSpy.mockRestore()
+  })
+
   it('shows an error Alert when a category browse fetch rejects', async () => {
     getSketchfabSearchHistoryMock.mockResolvedValue([])
     const fetchSpy = vi.spyOn(window, 'fetch').mockRejectedValue(new TypeError('Network down'))

--- a/src/components/SketchfabViewer.test.tsx
+++ b/src/components/SketchfabViewer.test.tsx
@@ -315,3 +315,63 @@ describe('SketchfabViewer unified search/UID input', () => {
     fetchSpy.mockRestore()
   })
 })
+
+describe('SketchfabViewer search loading and error feedback', () => {
+  it('shows a spinner while the search is in flight and hides it after the response resolves', async () => {
+    getSketchfabSearchHistoryMock.mockResolvedValue([])
+    let resolveFetch: ((value: Response) => void) | undefined
+    const fetchSpy = vi.spyOn(window, 'fetch').mockImplementation(
+      () => new Promise<Response>(resolve => { resolveFetch = resolve }),
+    )
+
+    render(<SketchfabViewer onFixAngle={vi.fn()} />)
+    await waitFor(() => expect(getSketchfabSearchHistoryMock).toHaveBeenCalled())
+
+    const input = screen.getByPlaceholderText('Search models or paste UID / URL...')
+    fireEvent.change(input, { target: { value: 'tree' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    // While the fetch is pending, MUI CircularProgress renders role="progressbar".
+    await waitFor(() => expect(screen.getByRole('progressbar')).toBeInTheDocument())
+
+    // Resolve the fetch — the spinner should disappear.
+    resolveFetch?.(new Response(JSON.stringify({ results: [], next: null })))
+    await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
+    fetchSpy.mockRestore()
+  })
+
+  it('shows an error Alert when the keyword search fetch rejects', async () => {
+    getSketchfabSearchHistoryMock.mockResolvedValue([])
+    const fetchSpy = vi.spyOn(window, 'fetch').mockRejectedValue(new TypeError('Network down'))
+
+    render(<SketchfabViewer onFixAngle={vi.fn()} />)
+    await waitFor(() => expect(getSketchfabSearchHistoryMock).toHaveBeenCalled())
+
+    const input = screen.getByPlaceholderText('Search models or paste UID / URL...')
+    fireEvent.change(input, { target: { value: 'tree' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    // role="alert" is what MUI Alert renders by default — assert via role rather
+    // than text so a localized message change doesn't break the test.
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/search failed/i)
+    // Spinner must not be left behind after the failure.
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    fetchSpy.mockRestore()
+  })
+
+  it('shows an error Alert when a category browse fetch rejects', async () => {
+    getSketchfabSearchHistoryMock.mockResolvedValue([])
+    const fetchSpy = vi.spyOn(window, 'fetch').mockRejectedValue(new TypeError('Network down'))
+
+    render(<SketchfabViewer onFixAngle={vi.fn()} />)
+    await waitFor(() => expect(getSketchfabSearchHistoryMock).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Animals' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/(failed|fetch)/i)
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    fetchSpy.mockRestore()
+  })
+})

--- a/src/components/SketchfabViewer.tsx
+++ b/src/components/SketchfabViewer.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { Box, Button, Chip, IconButton, Autocomplete, TextField, ToggleButton, ToggleButtonGroup, Typography, CircularProgress } from '@mui/material'
+import { Alert, Box, Button, Chip, IconButton, Autocomplete, TextField, ToggleButton, ToggleButtonGroup, Typography, CircularProgress } from '@mui/material'
 import { Trash2 } from 'lucide-react'
 import { t } from '../i18n'
 import type { ReferenceInfo } from '../types'
@@ -172,6 +172,7 @@ export function SketchfabViewer({
   const [activeCategory, setActiveCategory] = useState<SketchfabCategorySlug | null>(initialCategory ?? null)
   const [nextPageUrl, setNextPageUrl] = useState<string | null>(null)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [isSearching, setIsSearching] = useState(false)
   const lastSearchRef = useRef<
     | { type: 'search'; query: string; category?: SketchfabCategorySlug }
     | { type: 'category'; slug: SketchfabCategorySlug }
@@ -333,6 +334,7 @@ export function SketchfabViewer({
     lastSearchRef.current = { type: 'search', query: trimmedQuery, category }
     setActiveCategory(category ?? null)
     setError(null)
+    setIsSearching(true)
     try {
       // /v3/search supports keyword search but ignores published_since
       // /v3/models supports published_since but has poor keyword search
@@ -360,6 +362,8 @@ export function SketchfabViewer({
       recordSearch({ query: trimmedQuery, timeFilter: effectiveFilter, ...(category ? { category } : {}) })
     } catch {
       setError(t('searchFailed'))
+    } finally {
+      setIsSearching(false)
     }
   }, [timeFilter, recordSearch])
 
@@ -377,6 +381,7 @@ export function SketchfabViewer({
     const publishedSince = getPublishedSince(effectiveFilter)
     if (publishedSince) params.set('published_since', publishedSince)
 
+    setIsSearching(true)
     fetch(`https://api.sketchfab.com/v3/models?${params}`)
       .then(r => {
         if (!r.ok) throw new Error('Fetch failed')
@@ -388,6 +393,7 @@ export function SketchfabViewer({
         recordSearch({ query: '', category: categorySlug, timeFilter: effectiveFilter })
       })
       .catch(() => setError(t('failedFetchModels')))
+      .finally(() => setIsSearching(false))
   }, [timeFilter, recordSearch])
 
   // Clear the active category and fetch the unfiltered "all works" view —
@@ -642,7 +648,12 @@ export function SketchfabViewer({
           </Box>
 
           {!scriptLoaded && <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>{t('loadingApi')}</Typography>}
-          {error && <Typography variant="body2" color="error" sx={{ mb: 1 }}>{error}</Typography>}
+          {error && <Alert severity="error" sx={{ mb: 1 }}>{error}</Alert>}
+          {isSearching && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', my: 2 }}>
+              <CircularProgress size={28} />
+            </Box>
+          )}
 
           {/* Search results grid */}
           {searchResults.length > 0 && (

--- a/src/components/SketchfabViewer.tsx
+++ b/src/components/SketchfabViewer.tsx
@@ -173,6 +173,11 @@ export function SketchfabViewer({
   const [nextPageUrl, setNextPageUrl] = useState<string | null>(null)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const [isSearching, setIsSearching] = useState(false)
+  // Aborts the in-flight search/category fetch when a newer one starts so a
+  // slow earlier response can't overwrite faster newer results, and so
+  // isSearching/error state belongs to the latest request only.
+  const inflightSearchRef = useRef<AbortController | null>(null)
+  useEffect(() => () => inflightSearchRef.current?.abort(), [])
   const lastSearchRef = useRef<
     | { type: 'search'; query: string; category?: SketchfabCategorySlug }
     | { type: 'category'; slug: SketchfabCategorySlug }
@@ -334,6 +339,9 @@ export function SketchfabViewer({
     lastSearchRef.current = { type: 'search', query: trimmedQuery, category }
     setActiveCategory(category ?? null)
     setError(null)
+    inflightSearchRef.current?.abort()
+    const ctrl = new AbortController()
+    inflightSearchRef.current = ctrl
     setIsSearching(true)
     try {
       // /v3/search supports keyword search but ignores published_since
@@ -353,17 +361,21 @@ export function SketchfabViewer({
       const endpoint = useSearchEndpoint
         ? `https://api.sketchfab.com/v3/search?${params}`
         : `https://api.sketchfab.com/v3/models?${params}`
-      const res = await fetch(endpoint)
+      const res = await fetch(endpoint, { signal: ctrl.signal })
       if (!res.ok) throw new Error('Search failed')
 
       const data: SearchResponse = await res.json()
       setSearchResults(parseSearchResults(data))
       setNextPageUrl(data.next ?? null)
       recordSearch({ query: trimmedQuery, timeFilter: effectiveFilter, ...(category ? { category } : {}) })
-    } catch {
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') return
       setError(t('searchFailed'))
     } finally {
-      setIsSearching(false)
+      if (inflightSearchRef.current === ctrl) {
+        inflightSearchRef.current = null
+        setIsSearching(false)
+      }
     }
   }, [timeFilter, recordSearch])
 
@@ -371,6 +383,7 @@ export function SketchfabViewer({
     const effectiveFilter = filter ?? timeFilter
     lastSearchRef.current = { type: 'category', slug: categorySlug }
     setActiveCategory(categorySlug)
+    setError(null)
     const offset = Math.floor(Math.random() * 50)
     const params = new URLSearchParams({
       categories: categorySlug,
@@ -381,8 +394,11 @@ export function SketchfabViewer({
     const publishedSince = getPublishedSince(effectiveFilter)
     if (publishedSince) params.set('published_since', publishedSince)
 
+    inflightSearchRef.current?.abort()
+    const ctrl = new AbortController()
+    inflightSearchRef.current = ctrl
     setIsSearching(true)
-    fetch(`https://api.sketchfab.com/v3/models?${params}`)
+    fetch(`https://api.sketchfab.com/v3/models?${params}`, { signal: ctrl.signal })
       .then(r => {
         if (!r.ok) throw new Error('Fetch failed')
         return r.json()
@@ -392,8 +408,16 @@ export function SketchfabViewer({
         setNextPageUrl(data.next ?? null)
         recordSearch({ query: '', category: categorySlug, timeFilter: effectiveFilter })
       })
-      .catch(() => setError(t('failedFetchModels')))
-      .finally(() => setIsSearching(false))
+      .catch((e: unknown) => {
+        if (e instanceof DOMException && e.name === 'AbortError') return
+        setError(t('failedFetchModels'))
+      })
+      .finally(() => {
+        if (inflightSearchRef.current === ctrl) {
+          inflightSearchRef.current = null
+          setIsSearching(false)
+        }
+      })
   }, [timeFilter, recordSearch])
 
   // Clear the active category and fetch the unfiltered "all works" view —


### PR DESCRIPTION
## Summary

Codify the implicit UI conventions used across `src/components/**` into a path-scoped rule (`.claude/rules/ui-design-principles.md`) so future component work can stay consistent without re-deriving the patterns from existing code. Apply those principles to align small inconsistencies between the Sketchfab and Pexels search viewers, and tighten the Sketchfab search/category code paths along the way.

### What changed

**1. Design principles document (new `.claude/rules/ui-design-principles.md`, scoped to `src/components/**`)**
- Layout skeleton (40px top toolbar + content)
- Three-tier button model (toolbar IconButton / primary Button / source-picker Button)
- Stateful selection (`ToggleButtonGroup` / contained-vs-outlined Button rows) vs stateless shortcut (`Chip`)
- Modal vs inline confirmation patterns
- Error / loading severity mapping (`Alert severity="info"` for config blockers, `severity="error"` for failures, `CircularProgress` for in-flight)
- Autocomplete + history-dropdown conventions (default `openOnFocus`, `pointerdown` stopPropagation on delete)
- Result grid pattern, access-symmetry guidance
- Linked from `CLAUDE.md` "Detailed area rules"

**2. Search-viewer alignment (Pexels / Sketchfab)**
- `PexelsSearcher`: enable `Autocomplete` `openOnFocus` (history dropdown discoverability, matching Sketchfab)
- Both viewers: surface search errors via `Alert severity="error"` instead of `Typography color="error"`
- `SketchfabViewer`: show a centered `CircularProgress` while a search/category fetch is in flight (closes the previously silent gap before results appear)

**3. Sketchfab search hardening (review feedback)**
- Both `handleSearch` and `handleRandomFromCategory` now share an `inflightSearchRef` `AbortController` — a newer search aborts the previous fetch, and only the latest controller clears `isSearching` / applies results. Mirrors the existing pattern in `PexelsSearcher`.
- `handleRandomFromCategory` now clears `error` at the start so a stale error banner doesn't linger across category clicks (matching `handleSearch`).

**4. Tests**
- New `PexelsSearcher.test.tsx` covering `openOnFocus` history exposure, error-Alert path, and clean success path.
- `SketchfabViewer.test.tsx`: added spinner-while-pending, error-Alert (search and category paths), cleared-error-on-new-fetch, and stale-fetch-aborted tests.

### Maintained-but-different (justified in the principles doc)

- Sketchfab Categories use `Button`s (stateful with active highlight), Pexels Suggested uses `Chip`s (stateless quick-search). Different roles, different components.
- Sketchfab's dynamic `Load`/`Search` button label exists because UID/URL paste is supported there; Pexels has no such mode and stays with a fixed `Search`.
- Result grid `minmax(120px)` for Sketchfab thumbs vs `minmax(160px)` for Pexels photos — content-driven difference, kept as-is.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test` — 25 files / 382 tests (+8 added) all passing
- [x] Sketchfab pending-fetch spinner / error Alert (search + category) / cleared-error-on-new-fetch / stale-fetch-aborted — covered by automated tests
- [x] Pexels `openOnFocus` history dropdown / error Alert / clean-success no-Alert — covered by automated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)