### PR TITLE
fix: reset page zoom on search-screen transitions

### DIFF
--- a/src/components/PexelsSearcher.tsx
+++ b/src/components/PexelsSearcher.tsx
@@ -33,6 +33,7 @@ import {
 import type { ReferenceInfo } from '../types'
 import { t } from '../i18n'
 import { ToolbarTooltip } from './ToolbarTooltip'
+import { resetPageZoom } from '../utils/resetPageZoom'
 
 interface PexelsSearcherProps {
   onSelectPhoto: (info: Extract<ReferenceInfo, { source: 'pexels' }>, thumbnailUrl: string) => void
@@ -191,6 +192,7 @@ export function PexelsSearcher({ onSelectPhoto, onOpenApiKeySettings, initialQue
   }, [hasMore, loadingMore, activeQuery, activeOrientation, currentPage, handleError])
 
   const handleSelect = useCallback((photo: PexelsPhoto) => {
+    resetPageZoom()
     onSelectPhoto(buildPexelsReferenceInfo(photo), photo.src.tiny)
   }, [onSelectPhoto])
 
@@ -210,7 +212,7 @@ export function PexelsSearcher({ onSelectPhoto, onOpenApiKeySettings, initialQue
   }, [reloadHistory])
 
   return (
-    <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', overflow: 'auto', p: 1 }}>
+    <Box data-allow-page-zoom="true" sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', overflow: 'auto', p: 1, touchAction: 'pan-x pan-y pinch-zoom' }}>
       {needsKey && (
         <Alert severity="info" sx={{ mb: 1 }} action={
           <Button color="inherit" size="small" onClick={onOpenApiKeySettings}>

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -20,6 +20,7 @@ import {
 } from '../utils/pexels'
 import { addUrlHistory, getUrlHistory, getUrlHistoryEntry, deleteUrlHistory, type UrlHistoryEntry, type UrlHistoryType, type AddUrlHistoryOptions } from '../storage'
 import { resizeImageForHistory, dataUrlToJpegBlob, blobToDataUrl, sha256Hex } from '../utils/imageResize'
+import { resetPageZoom } from '../utils/resetPageZoom'
 import { resolveHistoryThumbnailSrc } from './urlHistoryThumbnail'
 import {
   canonicalSketchfabUrl,
@@ -666,6 +667,7 @@ export function ReferencePanel({
   }, [onReferenceChange])
 
   const handleClose = useCallback(() => {
+    resetPageZoom()
     onReferenceChange(s => {
       s.setSource('none')
       s.setReferenceMode('browse')

--- a/src/components/SketchfabViewer.tsx
+++ b/src/components/SketchfabViewer.tsx
@@ -20,6 +20,7 @@ import {
   type SketchfabSearchHistoryEntry,
 } from '../storage'
 import { ToolbarTooltip } from './ToolbarTooltip'
+import { resetPageZoom } from '../utils/resetPageZoom'
 
 export interface SketchfabFixAngleExtras {
   searchContext: SketchfabSearchContext | null
@@ -254,6 +255,7 @@ export function SketchfabViewer({
   }, [showViewer, scriptLoaded, initViewer])
 
   const loadModel = useCallback((uid: string, meta?: SketchfabModelMeta) => {
+    resetPageZoom()
     setShowViewer(true)
     setModelUid(uid)
     if (meta) {
@@ -522,7 +524,7 @@ export function SketchfabViewer({
 
       {/* Browse/search UI */}
       {!showViewer && (
-        <Box sx={{ flex: 1, overflow: 'auto', p: 1 }}>
+        <Box data-allow-page-zoom="true" sx={{ flex: 1, overflow: 'auto', p: 1, touchAction: 'pan-x pan-y pinch-zoom' }}>
           {/* Search row — Autocomplete shows the past-searches dropdown. */}
           <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
             <Autocomplete<SketchfabSearchHistoryEntry, false, false, true>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,25 +3,19 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-// Block trackpad / Ctrl+wheel page zoom. Browsers report trackpad pinch as
-// `wheel` with `ctrlKey: true`; otherwise the chrome and reference selection
-// screens silently page-zoom while the user means to pinch the canvas.
-// Self-rolled pinch (ImageViewer, YouTubeViewer, DrawingCanvas) keeps working —
-// each registers its own per-canvas `wheel` listener that still fires here.
-// iOS touch pinch and browser zoom (Cmd +/-, accessibility zoom) are intentionally
-// left available — viewport meta no longer locks scale, so users who need to zoom
-// can still do so.
-// Search screens (Sketchfab/Pexels result lists) opt back IN to page-zoom by
-// marking their scroll container with `data-allow-page-zoom="true"` so users can
-// peek at small thumbnails; `resetPageZoom()` restores 1.0 on screen transition.
-// Touch-device only: on macOS desktop, ctrl+wheel updates the BROWSER page-zoom
-// (same level as Cmd +/-) which has no JS reset API — leaving the user stuck if
-// we let it through. Use DevTools touch emulation to test the iOS path on Mac.
+// Block ctrl+wheel page-zoom (browsers report trackpad pinch as wheel+ctrlKey).
+// Self-rolled pinch in ImageViewer/YouTubeViewer/DrawingCanvas works via their
+// own per-canvas listeners. iOS touch pinch and Cmd +/- remain available.
+// Touch devices only: search screens (Sketchfab/Pexels) opt back in via
+// `data-allow-page-zoom="true"` so users can pinch small thumbnails;
+// resetPageZoom() restores 1.0 on screen transition. macOS ctrl+wheel is the
+// browser page-zoom (no JS reset API), so it stays blocked on desktop.
+const isTouchDevice = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0
 const preventCtrlWheelZoom = (e: WheelEvent) => {
   if (!e.ctrlKey) return
-  if (navigator.maxTouchPoints > 0) {
+  if (isTouchDevice) {
     const target = e.target as Element | null
-    if (target?.closest?.('[data-allow-page-zoom="true"]')) return
+    if (target?.closest('[data-allow-page-zoom="true"]')) return
   }
   e.preventDefault()
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,8 +11,19 @@ import App from './App.tsx'
 // iOS touch pinch and browser zoom (Cmd +/-, accessibility zoom) are intentionally
 // left available — viewport meta no longer locks scale, so users who need to zoom
 // can still do so.
+// Search screens (Sketchfab/Pexels result lists) opt back IN to page-zoom by
+// marking their scroll container with `data-allow-page-zoom="true"` so users can
+// peek at small thumbnails; `resetPageZoom()` restores 1.0 on screen transition.
+// Touch-device only: on macOS desktop, ctrl+wheel updates the BROWSER page-zoom
+// (same level as Cmd +/-) which has no JS reset API — leaving the user stuck if
+// we let it through. Use DevTools touch emulation to test the iOS path on Mac.
 const preventCtrlWheelZoom = (e: WheelEvent) => {
-  if (e.ctrlKey) e.preventDefault()
+  if (!e.ctrlKey) return
+  if (navigator.maxTouchPoints > 0) {
+    const target = e.target as Element | null
+    if (target?.closest?.('[data-allow-page-zoom="true"]')) return
+  }
+  e.preventDefault()
 }
 document.addEventListener('wheel', preventCtrlWheelZoom, { passive: false })
 

--- a/src/utils/resetPageZoom.ts
+++ b/src/utils/resetPageZoom.ts
@@ -1,12 +1,16 @@
+const meta = typeof document !== 'undefined'
+  ? document.querySelector<HTMLMetaElement>('meta[name="viewport"]')
+  : null
+// モジュール初期化時に元の content を1回だけ捕捉する。これで連続呼び出し時にも
+// stale な (maximum-scale=1.0 を含む) 値を「original」と誤認することがない。
+const ORIGINAL = meta?.getAttribute('content') ?? null
+
 export function resetPageZoom(): void {
-  const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]')
-  if (!meta) return
-  const original = meta.getAttribute('content') ?? ''
-  if (!original) return
+  if (!meta || !ORIGINAL) return
   // 一瞬 maximum-scale=1.0 を加えて Safari にページズームを 1.0 へ戻させ、
   // 次フレームで元へ戻す。これで以降の検索画面でも再びピンチズーム可能。
-  meta.setAttribute('content', `${original}, maximum-scale=1.0`)
+  meta.setAttribute('content', `${ORIGINAL}, maximum-scale=1.0`)
   requestAnimationFrame(() => {
-    meta.setAttribute('content', original)
+    meta.setAttribute('content', ORIGINAL)
   })
 }

--- a/src/utils/resetPageZoom.ts
+++ b/src/utils/resetPageZoom.ts
@@ -1,0 +1,12 @@
+export function resetPageZoom(): void {
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]')
+  if (!meta) return
+  const original = meta.getAttribute('content') ?? ''
+  if (!original) return
+  // 一瞬 maximum-scale=1.0 を加えて Safari にページズームを 1.0 へ戻させ、
+  // 次フレームで元へ戻す。これで以降の検索画面でも再びピンチズーム可能。
+  meta.setAttribute('content', `${original}, maximum-scale=1.0`)
+  requestAnimationFrame(() => {
+    meta.setAttribute('content', original)
+  })
+}


### PR DESCRIPTION
## Summary

- iPad で Sketchfab/Pexels の検索結果をピンチ拡大したままサムネイルを選択 (または Close で戻る) すると、ページレベルのズームが残り 40px のツールバーが画面外に押し出されて操作不能になっていた問題を修正
- `resetPageZoom()` ユーティリティを追加し、検索 → リファレンス確定 / Close の前進・後退の両遷移点でビューポートメタを一瞬差し替えて iOS の visual viewport を 1.0 に戻す
- 検索コンテナを `data-allow-page-zoom="true"` + `touch-action: pan-x pan-y pinch-zoom` でオプトインさせ、サムネイルを大きく見るためのピンチ自体は許可
- macOS デスクトップは `ctrl+wheel` がブラウザページズーム (Cmd +/- と同じ) を動かすが JS で戻す API が存在しないため、`navigator.maxTouchPoints > 0` のときだけオプトインを認めるようにし、Mac では従来どおり完全ブロック

## Test plan

- [x] `npm run lint` パス
- [x] `npm run test` パス (382 件)
- [x] `npm run build` パス
- [ ] 実機 iPad: Sketchfab 検索でピンチ拡大 → サムネイル選択でズームが 1.0 に戻りツールバーが見える
- [ ] 実機 iPad: 検索画面でピンチ拡大 → Close ボタンでソース選択画面へ戻る瞬間にズームが戻る
- [ ] 実機 iPad: Pexels でも同様 (前進・後退)
- [x] macOS Chrome DevTools のレスポンシブ/タッチエミュレーションで上記と同じ挙動になることを確認 (ユーザー確認済)
- [x] macOS 通常モード: 検索画面でも `ctrl+wheel` ピンチが効かないこと (commit 06700c8 の挙動を維持)
- [ ] 検索以外の画面 (描画パネル / ImageViewer / YouTubeViewer) でピンチが従来通り無効

🤖 Generated with [Claude Code](https://claude.com/claude-code)