### PR TITLE
ui: move reference-collapse toggle to drawing toolbar left edge

### DIFF
--- a/.claude/rules/ui-design-principles.md
+++ b/.claude/rules/ui-design-principles.md
@@ -17,6 +17,7 @@ When a new UI is added or an existing one is changed, check it against these pri
   2. Function-button group(s), separated by 1px vertical dividers (`Box sx={{ width: '1px', height: 24, bgcolor: '#ddd' }}`)
   3. `flex: 1` spacer
   4. View / navigation button group (grid, flip, zoom-reset, fullscreen, gallery, etc.)
+- **Exception**: DrawingPanel の reference-collapse トグルだけは toolbar の **左端** (Close/title 相当の位置) に置く。横長レイアウトでドローパネルが画面右側にあるため、左端がそのままリファレンス/ドローイング境界の真横になり、`PanelLeftOpen/Close` のアイコン方向とも一致するため。縦長でも同じ位置に置くことで、orientation を切り替えてもユーザーがトグル位置を覚えやすくする。
 
 ## 2. The three-tier button model
 

--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -214,6 +214,33 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
           minHeight: 40,
         }}
       >
+        {/* Reference panel collapse toggle is placed at the left end (instead
+            of the right view group) so it sits next to the reference/drawing
+            boundary in landscape mode and stays in a fixed spot across
+            orientations. See .claude/rules/ui-design-principles.md §1. */}
+        {onToggleReferenceCollapsed && (() => {
+          const icons = orientation === 'portrait'
+            ? { collapsed: PanelTopOpen, expanded: PanelTopClose }
+            : { collapsed: PanelLeftOpen, expanded: PanelLeftClose };
+          const Icon = referenceCollapsed ? icons.collapsed : icons.expanded;
+          const tooltip = collapseLocked
+            ? t('collapseLockedSketchfabBrowse')
+            : referenceCollapsed ? t('expandReference') : t('collapseReference');
+          const button = (
+            <IconButton size="small" onClick={onToggleReferenceCollapsed} disabled={collapseLocked} aria-label={tooltip}>
+              <Icon size={20} />
+            </IconButton>
+          );
+          return (
+            <>
+              <ToolbarTooltip title={tooltip}>
+                {collapseLocked ? <span>{button}</span> : button}
+              </ToolbarTooltip>
+              <Box sx={{ width: '1px', height: 24, bgcolor: '#ddd', mx: 0.5 }} />
+            </>
+          );
+        })()}
+
         {/* Drawing tools */}
         <ToolbarTooltip title={`${t('pen')} (P)`}>
           <IconButton
@@ -273,29 +300,6 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
         <Box sx={{ flex: 1 }} />
 
         {/* View */}
-        {onToggleReferenceCollapsed && (() => {
-          const icons = orientation === 'portrait'
-            ? { collapsed: PanelTopOpen, expanded: PanelTopClose }
-            : { collapsed: PanelLeftOpen, expanded: PanelLeftClose };
-          const Icon = referenceCollapsed ? icons.collapsed : icons.expanded;
-          const tooltip = collapseLocked
-            ? t('collapseLockedSketchfabBrowse')
-            : referenceCollapsed ? t('expandReference') : t('collapseReference');
-          // Only wrap in <span> when disabled — MUI suppresses tooltips on
-          // disabled buttons unless wrapped, but adding the span when enabled
-          // breaks the aria-label propagation tests rely on for queryByLabelText.
-          const button = (
-            <IconButton size="small" onClick={onToggleReferenceCollapsed} disabled={collapseLocked} aria-label={tooltip}>
-              <Icon size={20} />
-            </IconButton>
-          );
-          return (
-            <ToolbarTooltip title={tooltip}>
-              {collapseLocked ? <span>{button}</span> : button}
-            </ToolbarTooltip>
-          );
-        })()}
-
         <ToolbarTooltip title={t('resetZoom')}>
           <span>
             <IconButton


### PR DESCRIPTION
## Summary

- ドロー画面ツールバー中央スペーサー後ろにあったリファレンスパネル折りたたみトグルを、ツールバー **左端** に移動。Pen/Eraser との間に既存スタイルの 1px divider を追加。
- 横長レイアウトではドローパネルが画面右側にあるため、ツールバー左端がそのままリファレンス/ドローイング境界の真横になり、`PanelLeftOpen/Close` のアイコン方向と直感的に一致。縦長でも同じ位置に置くことで orientation を切り替えてもトグル位置を覚えやすい。
- `.claude/rules/ui-design-principles.md` §1 に「ビュー系は右」原則の意図的逸脱として例外注記を追加。

## Test plan

- [x] `npm run lint` — pass
- [x] `npm run test` — 391/391 pass
- [x] `npm run build` — pass
- [x] 横長で collapse トグルがツールバー最左端に出ること、トグルでパネルが折りたたみ/展開されること
- [x] 縦長に切り替え、アイコンが `PanelTopOpen/Close` に変わり、位置はやはり最左端のままであること
- [ ] リロードしても `referenceCollapsed` が autosave から復元されること
- [ ] undo/redo (Cmd+Z) で collapse 操作が引き続き undoable なこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)