### PR TITLE
fix: cancel in-progress stroke when pinch begins on touch devices

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -295,6 +295,17 @@ export function DrawingCanvas({
 
     // 2-finger pinch
     if (activeTouchesRef.current.size >= 2) {
+      // Cancel any in-progress single-finger stroke. On iPhone the second
+      // finger often lands a few frames after the first, and the small
+      // amount of motion in between would otherwise commit a stray line
+      // when the pinch ends.
+      if (mode === 'pen' && strokeManagerRef.current.getCurrentStroke()) {
+        strokeManagerRef.current.cancelStroke();
+        drawingPointCountRef.current = 0;
+        onCurrentStrokeChange?.(null);
+        requestRedraw();
+      }
+
       const ids = Array.from(activeTouchesRef.current.keys());
       const t1 = activeTouchesRef.current.get(ids[0])!;
       const t2 = activeTouchesRef.current.get(ids[1])!;
@@ -330,7 +341,7 @@ export function DrawingCanvas({
       strokeManagerRef.current.startStroke(point);
       drawingPointCountRef.current = 1;
     }
-  }, [mode, getCanvasPoint, onHighlightStroke, onDeleteHighlightedStroke, highlightedStrokeIndex, strokeManagerRef, getCurrentScale]);
+  }, [mode, getCanvasPoint, onHighlightStroke, onDeleteHighlightedStroke, highlightedStrokeIndex, strokeManagerRef, getCurrentScale, onCurrentStrokeChange, requestRedraw]);
 
   const handleTouchMove = useCallback((e: React.TouchEvent) => {
     e.preventDefault();

--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -67,7 +67,6 @@ export function DrawingCanvas({
     viewTransformRef.current = viewTransform ?? new ViewTransform();
   }
   const hasStylusRef = useRef(false);
-  const drawingPointCountRef = useRef(0);
   const rafIdRef = useRef<number>(0);
   // Latest container size in CSS pixels — refreshed on every ResizeObserver
   // tick. The camera transform projects against this on every read so layout
@@ -301,7 +300,6 @@ export function DrawingCanvas({
       // when the pinch ends.
       if (mode === 'pen' && strokeManagerRef.current.getCurrentStroke()) {
         strokeManagerRef.current.cancelStroke();
-        drawingPointCountRef.current = 0;
         onCurrentStrokeChange?.(null);
         requestRedraw();
       }
@@ -339,7 +337,6 @@ export function DrawingCanvas({
     }
     else {
       strokeManagerRef.current.startStroke(point);
-      drawingPointCountRef.current = 1;
     }
   }, [mode, getCanvasPoint, onHighlightStroke, onDeleteHighlightedStroke, highlightedStrokeIndex, strokeManagerRef, getCurrentScale, onCurrentStrokeChange, requestRedraw]);
 
@@ -444,7 +441,6 @@ export function DrawingCanvas({
     }
     else {
       strokeManagerRef.current.startStroke(point);
-      drawingPointCountRef.current = 1;
     }
   }, [mode, getCanvasPoint, onHighlightStroke, onDeleteHighlightedStroke, highlightedStrokeIndex, strokeManagerRef, getCurrentScale]);
 

--- a/src/drawing/StrokeManager.test.ts
+++ b/src/drawing/StrokeManager.test.ts
@@ -45,6 +45,48 @@ describe('StrokeManager', () => {
       expect(manager.getCurrentStroke()).toBeNull();
     });
 
+    it('cancelStroke discards the in-progress stroke without committing or affecting undo', () => {
+      manager.startStroke({ x: 0, y: 0 });
+      manager.appendStroke({ x: 5, y: 5 });
+      manager.appendStroke({ x: 10, y: 10 });
+      expect(manager.getCurrentStroke()!.points).toHaveLength(3);
+
+      manager.cancelStroke();
+
+      expect(manager.getCurrentStroke()).toBeNull();
+      expect(manager.getStrokes()).toHaveLength(0);
+      expect(manager.canUndo()).toBe(false);
+
+      // A subsequent endStroke must be a no-op (currentStroke already cleared)
+      expect(manager.endStroke()).toBeNull();
+      expect(manager.canUndo()).toBe(false);
+    });
+
+    it('cancelStroke is safe to call when no stroke is active', () => {
+      expect(() => manager.cancelStroke()).not.toThrow();
+      expect(manager.getCurrentStroke()).toBeNull();
+      expect(manager.canUndo()).toBe(false);
+    });
+
+    it('cancelStroke does not disturb previously committed strokes or undo stack', () => {
+      manager.startStroke({ x: 0, y: 0 });
+      manager.appendStroke({ x: 10, y: 10 });
+      manager.endStroke();
+      expect(manager.getStrokes()).toHaveLength(1);
+      expect(manager.canUndo()).toBe(true);
+
+      manager.startStroke({ x: 100, y: 100 });
+      manager.appendStroke({ x: 110, y: 110 });
+      manager.cancelStroke();
+
+      expect(manager.getStrokes()).toHaveLength(1);
+      expect(manager.canUndo()).toBe(true);
+      // The first (committed) stroke is still undoable
+      const undone = manager.undo();
+      expect(undone?.kind).toBe('stroke');
+      expect(manager.getStrokes()).toHaveLength(0);
+    });
+
     it('tracks current stroke during drawing', () => {
       manager.startStroke({ x: 0, y: 0 });
       expect(manager.getCurrentStroke()).not.toBeNull();

--- a/src/drawing/StrokeManager.ts
+++ b/src/drawing/StrokeManager.ts
@@ -62,6 +62,15 @@ export class StrokeManager {
     return stroke;
   }
 
+  /**
+   * Discard the in-progress stroke without committing it or touching the
+   * undo/redo stacks. Used when a multi-finger gesture takes over mid-stroke
+   * so a stray short line is not left behind.
+   */
+  cancelStroke(): void {
+    this.currentStroke = null;
+  }
+
   getCurrentStroke(): Stroke | null {
     return this.currentStroke;
   }


### PR DESCRIPTION
## Summary

- iPhone で 2本指ピンチをしようとすると、1本目の指が触れた瞬間からストロークが始まり、2本目が遅れて触れる間のわずかな動きで「短いゴミ線」が描画コミットされてしまう問題を修正
- `StrokeManager.cancelStroke()` を新設し、進行中ストロークを undo/redo を汚さずに破棄できるようにした
- `DrawingCanvas.handleTouchStart` のピンチ検知ブロックで、進行中のペンストロークがあれば `cancelStroke()` + redraw でクリア

ユーザーが \`startStroke\` の遅延（デッドバンド）を入れずにキャンセル方式を選択しているため、描画開始のレスポンスは現状維持。

## Test plan

- [x] `npm run lint` パス
- [x] `npm run build` パス
- [x] `npm run test` パス（394 件、`cancelStroke` のユニットテスト 3 件追加）
- [ ] PR Preview 環境で iPhone Safari からアクセスし、以下を確認
  - [x] 1本指でしっかり線を引ける（既存挙動の維持）
  - [x] 2本指ピンチ後にゴミ線が残らない
  - [x] ピンチ後に再び 1本指で描ける（regression なし）
  - [x] Undo に余計なエントリが積まれていない
  - [ ] Apple Pencil ユーザーの即時描画が維持されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)