### PR TITLE
Add project-level Codex skills

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -33,6 +33,7 @@ Perform these steps immediately without asking for confirmation unless a command
 4. Create the branch and commit:
    - Generate a concise branch name from the change, prefixed with `codex/`.
    - Create or switch to that branch.
+   - If creating `codex/<name>` fails with `unable to create directory for .git/refs/heads/codex/<name>` or `.git/index.lock: Operation not permitted`, treat it as a likely sandbox write-permission issue and rerun the same git command with approval/escalation. Do not infer that a plain `codex` branch exists unless `git branch --list 'codex'` or `git show-ref --verify refs/heads/codex` confirms it.
    - Stage all intended changes. Use `git add .` only after confirming it will not sweep in unrelated user work.
    - Generate a commit message that describes the purpose of the change. Mention doc updates if `CLAUDE.md`, `AGENTS.md`, or `README.md` changed.
    - Commit the staged changes.
@@ -45,4 +46,4 @@ Perform these steps immediately without asking for confirmation unless a command
 
 ## Failure Handling
 
-If a command fails, stop at the failing step and summarize the command, the relevant output, and what needs to be fixed. Do not continue to later GitHub steps after failed checks or failed git commands.
+If a command fails because the sandbox cannot write Git metadata, request approval and rerun the same command with escalation before stopping. For other command failures, stop at the failing step and summarize the command, the relevant output, and what needs to be fixed. Do not continue to later GitHub steps after failed checks or failed git commands.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -22,17 +22,19 @@ Perform these steps immediately without asking for confirmation unless a command
 
 2. Run prechecks on the current branch:
    - Run `npm run lint` and `npm run build`.
-   - Run them in parallel when the environment allows it.
-   - If either command fails, report the failure and stop before branching, committing, pushing, or opening a PR.
+   - Run targeted tests when the change touches behavior already covered by tests, or when AGENTS.md or the relevant `.claude/rules/` guidance asks for targeted tests. Use `npm run test -- <path-or-pattern>` when a focused test target is clear; otherwise explain why tests were not run.
+   - Run independent checks in parallel when the environment allows it.
+   - If any required check fails, report the failure and stop before branching, committing, pushing, or opening a PR.
 
 3. Check docs before committing:
    - Read `CLAUDE.md` if the change affects architecture, file structure, major components, or agent-facing workflow.
+   - Read `AGENTS.md` if the change affects Codex-facing workflow, repository instructions, agent skills, or project structure.
    - Read `README.md` if the change affects user-facing features, development commands, stack, setup, or usage.
    - Update those files only when the change materially requires it.
 
 4. Create the branch and commit:
    - Generate a concise branch name from the change, prefixed with `codex/`.
-   - Create or switch to that branch.
+   - Prefer creating a new branch. If the generated branch already exists locally or remotely, inspect it before reusing it: compare its commits and diff against `main`, check whether it already has an open PR, and only reuse it when it clearly represents the same current change set. Otherwise generate a different branch name.
    - If creating `codex/<name>` fails with `unable to create directory for .git/refs/heads/codex/<name>` or `.git/index.lock: Operation not permitted`, treat it as a likely sandbox write-permission issue and rerun the same git command with approval/escalation. Do not infer that a plain `codex` branch exists unless `git branch --list 'codex'` or `git show-ref --verify refs/heads/codex` confirms it.
    - Stage all intended changes. Use `git add .` only after confirming it will not sweep in unrelated user work.
    - Generate a commit message that describes the purpose of the change. Mention doc updates if `CLAUDE.md`, `AGENTS.md`, or `README.md` changed.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: create-pr
+description: Create a pull request for this repository from the current local changes. Use when the user says create-pr, asks to make a PR, says "PRにして", "pull requestを作って", or otherwise wants Codex to check, branch, commit, push, and open a GitHub PR for the current work.
+---
+
+# Create PR
+
+## Overview
+
+Run the repository's pre-PR checks, optionally update project docs if the change affects them, create a `codex/` branch, commit all intended changes, push it, and open a PR against `main`.
+
+## Workflow
+
+Perform these steps immediately without asking for confirmation unless a command fails or the worktree contains unrelated changes that would make staging everything unsafe.
+
+1. Inspect repository state:
+   - Run `git status`.
+   - Run `git diff HEAD`.
+   - Run `git branch --show-current`.
+   - Run `git log --oneline -10`.
+   - Identify the intended change set and whether unrelated user changes are present.
+
+2. Run prechecks on the current branch:
+   - Run `npm run lint` and `npm run build`.
+   - Run them in parallel when the environment allows it.
+   - If either command fails, report the failure and stop before branching, committing, pushing, or opening a PR.
+
+3. Check docs before committing:
+   - Read `CLAUDE.md` if the change affects architecture, file structure, major components, or agent-facing workflow.
+   - Read `README.md` if the change affects user-facing features, development commands, stack, setup, or usage.
+   - Update those files only when the change materially requires it.
+
+4. Create the branch and commit:
+   - Generate a concise branch name from the change, prefixed with `codex/`.
+   - Create or switch to that branch.
+   - Stage all intended changes. Use `git add .` only after confirming it will not sweep in unrelated user work.
+   - Generate a commit message that describes the purpose of the change. Mention doc updates if `CLAUDE.md`, `AGENTS.md`, or `README.md` changed.
+   - Commit the staged changes.
+
+5. Push and open the PR:
+   - Push the branch to `origin`.
+   - Create a PR against `main`.
+   - Use a PR body with a short summary and the validation results from the prechecks.
+   - Report the PR URL.
+
+## Failure Handling
+
+If a command fails, stop at the failing step and summarize the command, the relevant output, and what needs to be fixed. Do not continue to later GitHub steps after failed checks or failed git commands.

--- a/.agents/skills/create-pr/agents/openai.yaml
+++ b/.agents/skills/create-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create PR"
+  short_description: "Run checks, commit changes, push, and open a PR"
+  default_prompt: "Create a pull request for the current changes."

--- a/.agents/skills/merged/SKILL.md
+++ b/.agents/skills/merged/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: merged
+description: Clean up the local repository after a PR branch has been merged. Use when the user says merged, "マージした", "後始末して", "clean up", or otherwise asks Codex to switch back to main, pull the latest main, delete the merged local branch, and prune stale remote-tracking branches.
+---
+
+# Merged Cleanup
+
+## Overview
+
+Return the repository to an up-to-date `main` checkout after a PR merge and remove the merged local branch.
+
+## Workflow
+
+Perform these steps immediately without asking for confirmation unless the worktree has uncommitted changes that would be affected by switching branches.
+
+1. Determine the branch to clean up:
+   - If the user supplied a branch name, use it.
+   - Otherwise use `git branch --show-current`.
+   - Save that branch name before switching.
+
+2. Check the worktree:
+   - Run `git status`.
+   - If there are uncommitted changes, stop and report that cleanup cannot safely continue until they are committed, stashed, or discarded by the user.
+
+3. Update `main`:
+   - Switch to `main`.
+   - Pull the latest changes from `origin/main`.
+
+4. Remove stale branch state:
+   - Delete the merged local branch with `git branch -D <branch>`.
+   - Do not attempt to delete `main`.
+   - Run `git remote prune origin`.
+
+5. Summarize the cleanup:
+   - Report the branch removed.
+   - Report the current branch.
+   - Report the pulled main status or latest commit.
+
+## Failure Handling
+
+If any git command fails, stop and summarize the failing command and relevant output. Do not retry destructive branch deletion with a different target unless the user explicitly asks.

--- a/.agents/skills/merged/SKILL.md
+++ b/.agents/skills/merged/SKILL.md
@@ -15,7 +15,8 @@ Perform these steps immediately without asking for confirmation unless the workt
 
 1. Determine the branch to clean up:
    - If the user supplied a branch name, use it.
-   - Otherwise use `git branch --show-current`.
+   - Otherwise use `git branch --show-current` only when the current branch is not `main`.
+   - If the current branch is `main` and the user did not supply a branch name, stop and ask for the merged branch name instead of guessing.
    - Save that branch name before switching.
 
 2. Check the worktree:
@@ -27,8 +28,11 @@ Perform these steps immediately without asking for confirmation unless the workt
    - Pull the latest changes from `origin/main`.
 
 4. Remove stale branch state:
-   - Delete the merged local branch with `git branch -D <branch>`.
    - Do not attempt to delete `main`.
+   - Verify the branch is merged into the updated `main` with `git branch --merged main --list <branch>` or an equivalent reachability check.
+   - If the branch is not listed as merged, stop and report that cleanup cannot safely delete it.
+   - Delete the merged local branch with `git branch -d <branch>`.
+   - Use `git branch -D <branch>` only if the branch was verified as merged but `-d` still fails for a mechanical reason, and explain that fallback.
    - Run `git remote prune origin`.
 
 5. Summarize the cleanup:

--- a/.agents/skills/merged/agents/openai.yaml
+++ b/.agents/skills/merged/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Merged Cleanup"
+  short_description: "Clean up the local branch after a PR merge"
+  default_prompt: "Clean up after the current PR has been merged."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,12 @@ Read the relevant rule document before changing those areas. Keep `AGENTS.md` as
 - When working in an area covered by `.claude/rules/`, read the matching rule document alongside the code before editing.
 - Run `npm run lint` after meaningful code changes. Run targeted tests when behavior is covered by tests; add tests when the changed logic is isolated enough to justify them.
 
+## Project Codex Skills
+
+- `.agents/skills/create-pr`: check, branch, commit, push, and open a PR for the current changes.
+- `.agents/skills/merged`: switch back to `main`, pull, delete the merged local branch, and prune stale remote refs.
+- Invoke skills explicitly with `$create-pr` or `$merged`. In the Codex app, enabled skills may also appear in the slash command list after Codex reloads skill discovery.
+
 ## When In Doubt
 
 - Read code over relying on this file. This document is only a map of stable constraints and entry points.


### PR DESCRIPTION
## Summary
- Add project-level Codex skills for PR creation and post-merge cleanup
- Document explicit skill invocation in AGENTS.md

## Validation
- npm run lint
- npm run build
- YAML parse check for SKILL.md and openai.yaml files