### PR TITLE
test: silence jsdom Canvas getContext warnings

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -6,3 +6,26 @@ globalThis.ResizeObserver = class ResizeObserver {
   unobserve() {}
   disconnect() {}
 } as unknown as typeof globalThis.ResizeObserver;
+
+// jsdom doesn't implement Canvas 2D — return a no-op context so call sites
+// (generateThumbnail, imageResize) don't spam "Not implemented" warnings.
+const noopCtx = new Proxy({}, {
+  get: (_, prop) => {
+    if (prop === 'canvas') return undefined;
+    return () => {};
+  },
+  set: () => true,
+});
+HTMLCanvasElement.prototype.getContext = function getContext(this: HTMLCanvasElement, type: string) {
+  if (type === '2d') {
+    (noopCtx as { canvas?: HTMLCanvasElement }).canvas = this;
+    return noopCtx;
+  }
+  return null;
+} as HTMLCanvasElement['getContext'];
+HTMLCanvasElement.prototype.toDataURL = function toDataURL() {
+  return 'data:image/png;base64,';
+};
+HTMLCanvasElement.prototype.toBlob = function toBlob(cb: BlobCallback, type?: string) {
+  queueMicrotask(() => cb(new Blob([], { type: type ?? 'image/png' })));
+};

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -10,18 +10,11 @@ globalThis.ResizeObserver = class ResizeObserver {
 // jsdom doesn't implement Canvas 2D — return a no-op context so call sites
 // (generateThumbnail, imageResize) don't spam "Not implemented" warnings.
 const noopCtx = new Proxy({}, {
-  get: (_, prop) => {
-    if (prop === 'canvas') return undefined;
-    return () => {};
-  },
+  get: () => () => {},
   set: () => true,
 });
-HTMLCanvasElement.prototype.getContext = function getContext(this: HTMLCanvasElement, type: string) {
-  if (type === '2d') {
-    (noopCtx as { canvas?: HTMLCanvasElement }).canvas = this;
-    return noopCtx;
-  }
-  return null;
+HTMLCanvasElement.prototype.getContext = function getContext(type: string) {
+  return type === '2d' ? noopCtx : null;
 } as HTMLCanvasElement['getContext'];
 HTMLCanvasElement.prototype.toDataURL = function toDataURL() {
   return 'data:image/png;base64,';


### PR DESCRIPTION
## Summary

- jsdom doesn't implement Canvas 2D, so `npm run test` spammed "Not implemented: HTMLCanvasElement's getContext() method" warnings whenever a test path executed `generateThumbnail` (`src/storage/generateThumbnail.ts`) or `imageResize` (`src/utils/imageResize.ts`).
- Added a no-op `getContext` / `toDataURL` / `toBlob` stub to `src/test/setup.ts`, matching the existing hand-rolled ResizeObserver mock style — no new dependency, no production code touched.
- Existing `vi.mock('../storage/generateThumbnail', ...)` in `DrawingPanel.test.tsx` is unaffected (still controls return values for that test).

## Test plan

- [x] `npm run test` — 28 files / 418 tests pass, no Canvas warnings in output
- [x] `npm run lint` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)