### PR TITLE
test: silence act() warnings and Pexels error log noise

### DIFF
--- a/src/components/PexelsSearcher.test.tsx
+++ b/src/components/PexelsSearcher.test.tsx
@@ -66,6 +66,10 @@ describe('PexelsSearcher history dropdown', () => {
 describe('PexelsSearcher search error feedback', () => {
   it('shows an error Alert when the search fetch fails', async () => {
     const fetchSpy = vi.spyOn(window, 'fetch').mockRejectedValue(new TypeError('Network down'));
+    // The component logs the network error via console.error on this branch;
+    // silence it here so the deliberate-failure path doesn't dump a stack trace
+    // into the test output.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     render(<PexelsSearcher onSelectPhoto={vi.fn()} onOpenApiKeySettings={vi.fn()} />);
     await waitFor(() => expect(getPexelsSearchHistoryMock).toHaveBeenCalled());
@@ -79,6 +83,7 @@ describe('PexelsSearcher search error feedback', () => {
     expect(alert.textContent).toBeTruthy();
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     fetchSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('does not surface an Alert when fetch succeeds', async () => {

--- a/src/components/PexelsSearcher.test.tsx
+++ b/src/components/PexelsSearcher.test.tsx
@@ -64,12 +64,18 @@ describe('PexelsSearcher history dropdown', () => {
 });
 
 describe('PexelsSearcher search error feedback', () => {
+  // Restore window.fetch / console.error spies even if an assertion throws
+  // mid-test, so a failed test doesn't leak its mocks into the next one.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('shows an error Alert when the search fetch fails', async () => {
-    const fetchSpy = vi.spyOn(window, 'fetch').mockRejectedValue(new TypeError('Network down'));
+    vi.spyOn(window, 'fetch').mockRejectedValue(new TypeError('Network down'));
     // The component logs the network error via console.error on this branch;
     // silence it here so the deliberate-failure path doesn't dump a stack trace
     // into the test output.
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     render(<PexelsSearcher onSelectPhoto={vi.fn()} onOpenApiKeySettings={vi.fn()} />);
     await waitFor(() => expect(getPexelsSearchHistoryMock).toHaveBeenCalled());
@@ -82,8 +88,6 @@ describe('PexelsSearcher search error feedback', () => {
     // pexelsNetworkError content; matching loosely so locale changes don't break.
     expect(alert.textContent).toBeTruthy();
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
-    fetchSpy.mockRestore();
-    errorSpy.mockRestore();
   });
 
   it('does not surface an Alert when fetch succeeds', async () => {
@@ -104,6 +108,5 @@ describe('PexelsSearcher search error feedback', () => {
     // The needsKey info Alert is gated on missing key — with a key set it should
     // not be present, so any role="alert" here would be the error banner.
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-    fetchSpy.mockRestore();
   });
 });

--- a/src/components/ReferencePanel.test.tsx
+++ b/src/components/ReferencePanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { vi, type Mock } from 'vitest';
 import type { UrlHistoryEntry } from '../storage/db';
 import { buildYouTubeThumbnailUrl } from '../utils/youtube';
@@ -134,7 +134,7 @@ describe('ReferencePanel ObjectURL lifecycle (via SplitLayout)', () => {
 
     const { unmount } = render(<SplitLayout />);
     // Wait for the URL-history reload effect to settle so imageThumbUrls is built.
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(createObjectURLSpy).toHaveBeenCalledTimes(2);
     });
     expect(revokeObjectURLSpy).not.toHaveBeenCalled();
@@ -156,7 +156,7 @@ describe('ReferencePanel ObjectURL lifecycle (via SplitLayout)', () => {
 
     render(<SplitLayout />);
     // Source-selection screen has rendered; URL input is now in the DOM.
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(screen.getByPlaceholderText(/URL/i)).toBeInTheDocument();
     });
 
@@ -191,7 +191,7 @@ describe('ReferencePanel ObjectURL lifecycle (via SplitLayout)', () => {
     getUrlHistoryMock.mockResolvedValue([]);
 
     const { container } = render(<SplitLayout />);
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(screen.getByText('Sketchfab')).toBeInTheDocument();
     });
 
@@ -228,12 +228,12 @@ describe('ReferencePanel ObjectURL lifecycle (via SplitLayout)', () => {
     ]);
 
     render(<SplitLayout />);
-    await vi.waitFor(() => {
+    await waitFor(() => {
       // SplitLayout has settled when the source-selection screen is showing
       // (which it does whenever no source is loaded, including post-mount).
       expect(screen.getByText('Sketchfab')).toBeInTheDocument();
     });
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
## Summary

Follow-up to #144 — clean up the two remaining stderr noise sources in `npm run test`:

- `src/components/ReferencePanel.test.tsx` — `vi.waitFor` doesn't wrap re-evaluations in `act()`, so the `SplitLayout` URL-history fetch + setState produced 8 "An update to ReferencePanel inside a test was not wrapped in act(...)" warnings across 4 tests. Switched the 5 call sites to RTL's `waitFor`, which auto-wraps in `act()`.
- `src/components/PexelsSearcher.test.tsx` — the deliberate network-failure test triggers `console.error('Pexels error:', e)` in production code (`PexelsSearcher.tsx:114`), dumping a stack trace into test output. Scoped a `console.error` spy to that one test (other tests can still see real errors).

No production code changes; the diagnostic `console.error` stays intact for runtime use.

## Test plan

- [x] `npx vitest run --reporter=verbose 2>&1 1>/dev/null | grep -E "stderr|act\\(|Pexels error|not wrapped"` → zero output
- [x] `npm run test` — 28 files / 418 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)