### PR TITLE
perf: lazy-load Gallery, SketchfabViewer, PexelsSearcher

### DIFF
--- a/src/components/DrawingPanel.test.tsx
+++ b/src/components/DrawingPanel.test.tsx
@@ -272,8 +272,8 @@ describe('DrawingPanel keyboard shortcuts × Gallery', () => {
     document.dispatchEvent(event);
   }
 
-  it('suppresses Ctrl+Z undo while Gallery is open, and re-enables it on close', () => {
-    const { container, harness, getByTestId, queryByTestId } = setup();
+  it('suppresses Ctrl+Z undo while Gallery is open, and re-enables it on close', async () => {
+    const { container, harness, findByTestId, queryByTestId } = setup();
 
     // Arrange: one stroke on the manager, timer started via canvas callback.
     act(() => {
@@ -287,7 +287,9 @@ describe('DrawingPanel keyboard shortcuts × Gallery', () => {
     act(() => {
       fireEvent.click(galleryBtn);
     });
-    expect(getByTestId('gallery-stub')).toBeInTheDocument();
+    // Gallery is lazy-loaded; await the Suspense to resolve to the stub.
+    const galleryStub = await findByTestId('gallery-stub');
+    expect(galleryStub).toBeInTheDocument();
     expect(harness.timer.isRunning).toBe(false);
 
     // Ctrl+Z should be ignored — stroke stays.
@@ -298,7 +300,7 @@ describe('DrawingPanel keyboard shortcuts × Gallery', () => {
 
     // Close Gallery via the stub's button.
     act(() => {
-      fireEvent.click(getByTestId('gallery-stub').querySelector('button')!);
+      fireEvent.click(galleryStub.querySelector('button')!);
     });
     expect(queryByTestId('gallery-stub')).not.toBeInTheDocument();
 

--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -1,5 +1,5 @@
-import { useRef, useState, useCallback, useEffect, useMemo } from 'react';
-import { Box, IconButton, Popover, Typography } from '@mui/material';
+import { useRef, useState, useCallback, useEffect, useMemo, lazy, Suspense } from 'react';
+import { Box, CircularProgress, IconButton, Popover, Typography } from '@mui/material';
 import { ToolbarTooltip } from './ToolbarTooltip';
 import { Pen, Eraser, LassoSelect, Undo2, Redo2, Trash2, LocateFixed, Save, Check, Images, X, PanelLeftClose, PanelLeftOpen, PanelTopClose, PanelTopOpen } from 'lucide-react';
 import { useLongPress } from '../hooks/useLongPress';
@@ -12,8 +12,11 @@ import { formatTime, type TimerHandle } from '../hooks/useTimer';
 import { useKeyboardShortcuts, getModifierPrefix } from '../hooks/useKeyboardShortcuts';
 import { saveDrawing } from '../storage';
 import { generateThumbnail } from '../storage/generateThumbnail';
-import { Gallery } from './Gallery';
 import { t } from '../i18n';
+
+// Gallery is a modal opened on demand via the "Gallery" toolbar button —
+// keep it out of the initial bundle.
+const Gallery = lazy(() => import('./Gallery').then(m => ({ default: m.Gallery })));
 import type { ReferenceInfo } from '../types';
 import type { Stroke, ReferenceSnapshot } from '../drawing/types';
 
@@ -558,7 +561,26 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
         />
       </Box>
 
-      {showGallery && <Gallery onClose={() => setShowGallery(false)} onLoadReference={onLoadReference} />}
+      {showGallery && (
+        <Suspense
+          fallback={(
+            <Box sx={{
+              position: 'fixed',
+              inset: 0,
+              bgcolor: 'rgba(0,0,0,0.4)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              zIndex: 1000,
+            }}
+            >
+              <CircularProgress />
+            </Box>
+          )}
+        >
+          <Gallery onClose={() => setShowGallery(false)} onLoadReference={onLoadReference} />
+        </Suspense>
+      )}
     </Box>
   );
 }

--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -12,13 +12,14 @@ import { formatTime, type TimerHandle } from '../hooks/useTimer';
 import { useKeyboardShortcuts, getModifierPrefix } from '../hooks/useKeyboardShortcuts';
 import { saveDrawing } from '../storage';
 import { generateThumbnail } from '../storage/generateThumbnail';
+import { LazyErrorBoundary } from './LazyErrorBoundary';
 import { t } from '../i18n';
+import type { ReferenceInfo } from '../types';
+import type { Stroke, ReferenceSnapshot } from '../drawing/types';
 
 // Gallery is a modal opened on demand via the "Gallery" toolbar button —
 // keep it out of the initial bundle.
 const Gallery = lazy(() => import('./Gallery').then(m => ({ default: m.Gallery })));
-import type { ReferenceInfo } from '../types';
-import type { Stroke, ReferenceSnapshot } from '../drawing/types';
 
 interface DrawingPanelProps {
   referenceSize?: { width: number; height: number } | null;
@@ -562,24 +563,26 @@ export function DrawingPanel({ referenceSize, referenceInfo, onStrokeManagerRead
       </Box>
 
       {showGallery && (
-        <Suspense
-          fallback={(
-            <Box sx={{
-              position: 'fixed',
-              inset: 0,
-              bgcolor: 'rgba(0,0,0,0.4)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              zIndex: 1000,
-            }}
-            >
-              <CircularProgress />
-            </Box>
-          )}
-        >
-          <Gallery onClose={() => setShowGallery(false)} onLoadReference={onLoadReference} />
-        </Suspense>
+        <LazyErrorBoundary>
+          <Suspense
+            fallback={(
+              <Box sx={{
+                position: 'fixed',
+                inset: 0,
+                bgcolor: 'rgba(0,0,0,0.4)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                zIndex: 1000,
+              }}
+              >
+                <CircularProgress />
+              </Box>
+            )}
+          >
+            <Gallery onClose={() => setShowGallery(false)} onLoadReference={onLoadReference} />
+          </Suspense>
+        </LazyErrorBoundary>
       )}
     </Box>
   );

--- a/src/components/LazyErrorBoundary.tsx
+++ b/src/components/LazyErrorBoundary.tsx
@@ -1,0 +1,41 @@
+import { Component, type ReactNode } from 'react';
+import { Alert, Button } from '@mui/material';
+import { t } from '../i18n';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+// Catches errors thrown by React.lazy() chunk loads so a transient network
+// failure or a stale tab referencing chunks that were removed by a redeploy
+// doesn't crash the entire surrounding panel. Offers a one-click reload.
+export class LazyErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Alert
+          severity="error"
+          action={(
+            <Button color="inherit" size="small" onClick={() => window.location.reload()}>
+              {t('reload')}
+            </Button>
+          )}
+          sx={{ m: 2 }}
+        >
+          {t('lazyChunkLoadFailed')}
+        </Alert>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -7,6 +7,7 @@ import { ImageViewer, type GuideInteractionMode } from './ImageViewer';
 import type { ViewTransform } from '../drawing/ViewTransform';
 import { YouTubeViewer, type YouTubePlayerHandle } from './YouTubeViewer';
 import { PexelsApiKeyDialog } from './PexelsApiKeyDialog';
+import { LazyErrorBoundary } from './LazyErrorBoundary';
 
 // Heavy on-demand panels — only mounted when the user picks the matching
 // reference source. Splitting them out keeps them off the initial bundle.
@@ -1396,17 +1397,19 @@ export function ReferencePanel({
             search context restored from the URL-history entry. */}
         {source === 'sketchfab' && (
           <Box sx={{ display: referenceMode === 'browse' ? 'contents' : 'none' }}>
-            <Suspense fallback={<LazyPanelFallback />}>
-              <SketchfabViewer
-                key={sketchfabRestore?.token ?? 0}
-                onFixAngle={handleFixAngle}
-                onStateChange={handleSfStateChange}
-                actionsRef={sfActionsRef}
-                initialQuery={sketchfabRestore?.query}
-                initialTimeFilter={sketchfabRestore?.timeFilter}
-                initialCategory={sketchfabRestore?.category}
-              />
-            </Suspense>
+            <LazyErrorBoundary>
+              <Suspense fallback={<LazyPanelFallback />}>
+                <SketchfabViewer
+                  key={sketchfabRestore?.token ?? 0}
+                  onFixAngle={handleFixAngle}
+                  onStateChange={handleSfStateChange}
+                  actionsRef={sfActionsRef}
+                  initialQuery={sketchfabRestore?.query}
+                  initialTimeFilter={sketchfabRestore?.timeFilter}
+                  initialCategory={sketchfabRestore?.category}
+                />
+              </Suspense>
+            </LazyErrorBoundary>
           </Box>
         )}
 
@@ -1417,16 +1420,18 @@ export function ReferencePanel({
             search context restored from the URL-history entry. */}
         {source === 'pexels' && (
           <Box sx={{ display: referenceMode === 'browse' ? 'contents' : 'none' }}>
-            <Suspense fallback={<LazyPanelFallback />}>
-              <PexelsSearcher
-                key={pexelsRestore?.token ?? 0}
-                onSelectPhoto={handleSelectPexelsPhoto}
-                onOpenApiKeySettings={() => setPexelsKeyDialogOpen(true)}
-                apiKeyVersion={pexelsKeyVersion}
-                initialQuery={pexelsRestore?.query}
-                initialOrientation={pexelsRestore?.orientation}
-              />
-            </Suspense>
+            <LazyErrorBoundary>
+              <Suspense fallback={<LazyPanelFallback />}>
+                <PexelsSearcher
+                  key={pexelsRestore?.token ?? 0}
+                  onSelectPhoto={handleSelectPexelsPhoto}
+                  onOpenApiKeySettings={() => setPexelsKeyDialogOpen(true)}
+                  apiKeyVersion={pexelsKeyVersion}
+                  initialQuery={pexelsRestore?.query}
+                  initialOrientation={pexelsRestore?.orientation}
+                />
+              </Suspense>
+            </LazyErrorBoundary>
           </Box>
         )}
 

--- a/src/components/ReferencePanel.tsx
+++ b/src/components/ReferencePanel.tsx
@@ -1,13 +1,25 @@
-import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
-import { Box, Button, IconButton, Typography, TextField, Link as MuiLink, Autocomplete } from '@mui/material';
+import { useState, useCallback, useRef, useEffect, useMemo, lazy, Suspense } from 'react';
+import { Box, Button, CircularProgress, IconButton, Typography, TextField, Link as MuiLink, Autocomplete } from '@mui/material';
 import { ToolbarTooltip } from './ToolbarTooltip';
 import { X, PenLine, CircleX, Trash2, Layers, FlipHorizontal2, LocateFixed, Maximize, Minimize, Info, Film, Camera, Image as ImageIcon, Play, Pause, ZoomIn, Boxes, FolderOpen, KeyRound } from 'lucide-react';
-import { SketchfabViewer, type SketchfabActions, type SketchfabFixAngleExtras, type SketchfabModelMeta } from './SketchfabViewer';
+import type { SketchfabActions, SketchfabFixAngleExtras, SketchfabModelMeta } from './SketchfabViewer';
 import { ImageViewer, type GuideInteractionMode } from './ImageViewer';
 import type { ViewTransform } from '../drawing/ViewTransform';
 import { YouTubeViewer, type YouTubePlayerHandle } from './YouTubeViewer';
-import { PexelsSearcher } from './PexelsSearcher';
 import { PexelsApiKeyDialog } from './PexelsApiKeyDialog';
+
+// Heavy on-demand panels — only mounted when the user picks the matching
+// reference source. Splitting them out keeps them off the initial bundle.
+const SketchfabViewer = lazy(() => import('./SketchfabViewer').then(m => ({ default: m.SketchfabViewer })));
+const PexelsSearcher = lazy(() => import('./PexelsSearcher').then(m => ({ default: m.PexelsSearcher })));
+
+function LazyPanelFallback() {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1, my: 2 }}>
+      <CircularProgress />
+    </Box>
+  );
+}
 import { GitHubIcon } from './GitHubIcon';
 import { parseYouTubeVideoId, fetchYouTubeTitle } from '../utils/youtube';
 import {
@@ -1384,15 +1396,17 @@ export function ReferencePanel({
             search context restored from the URL-history entry. */}
         {source === 'sketchfab' && (
           <Box sx={{ display: referenceMode === 'browse' ? 'contents' : 'none' }}>
-            <SketchfabViewer
-              key={sketchfabRestore?.token ?? 0}
-              onFixAngle={handleFixAngle}
-              onStateChange={handleSfStateChange}
-              actionsRef={sfActionsRef}
-              initialQuery={sketchfabRestore?.query}
-              initialTimeFilter={sketchfabRestore?.timeFilter}
-              initialCategory={sketchfabRestore?.category}
-            />
+            <Suspense fallback={<LazyPanelFallback />}>
+              <SketchfabViewer
+                key={sketchfabRestore?.token ?? 0}
+                onFixAngle={handleFixAngle}
+                onStateChange={handleSfStateChange}
+                actionsRef={sfActionsRef}
+                initialQuery={sketchfabRestore?.query}
+                initialTimeFilter={sketchfabRestore?.timeFilter}
+                initialCategory={sketchfabRestore?.category}
+              />
+            </Suspense>
           </Box>
         )}
 
@@ -1403,14 +1417,16 @@ export function ReferencePanel({
             search context restored from the URL-history entry. */}
         {source === 'pexels' && (
           <Box sx={{ display: referenceMode === 'browse' ? 'contents' : 'none' }}>
-            <PexelsSearcher
-              key={pexelsRestore?.token ?? 0}
-              onSelectPhoto={handleSelectPexelsPhoto}
-              onOpenApiKeySettings={() => setPexelsKeyDialogOpen(true)}
-              apiKeyVersion={pexelsKeyVersion}
-              initialQuery={pexelsRestore?.query}
-              initialOrientation={pexelsRestore?.orientation}
-            />
+            <Suspense fallback={<LazyPanelFallback />}>
+              <PexelsSearcher
+                key={pexelsRestore?.token ?? 0}
+                onSelectPhoto={handleSelectPexelsPhoto}
+                onOpenApiKeySettings={() => setPexelsKeyDialogOpen(true)}
+                apiKeyVersion={pexelsKeyVersion}
+                initialQuery={pexelsRestore?.query}
+                initialOrientation={pexelsRestore?.orientation}
+              />
+            </Suspense>
           </Box>
         )}
 

--- a/src/components/SplitLayout.test.tsx
+++ b/src/components/SplitLayout.test.tsx
@@ -171,7 +171,7 @@ describe('SplitLayout', () => {
       expect(screen.getByText('Image File')).toBeInTheDocument();
     });
 
-    it('enables undo after opening Pexels and reverts to none on undo', () => {
+    it('enables undo after opening Pexels and reverts to none on undo', async () => {
       const { container } = render(<SplitLayout />);
 
       expect(screen.getByText('Pexels')).toBeInTheDocument();
@@ -181,8 +181,9 @@ describe('SplitLayout', () => {
 
       // Source selection UI is replaced with Pexels searcher
       expect(screen.queryByText('Image File')).not.toBeInTheDocument();
-      // Search input (from PexelsSearcher placeholder) is visible
-      expect(screen.getByPlaceholderText(/Search photos/i)).toBeInTheDocument();
+      // Search input (from PexelsSearcher placeholder) is visible — wait for
+      // the lazy chunk to resolve before asserting on its DOM.
+      expect(await screen.findByPlaceholderText(/Search photos/i)).toBeInTheDocument();
       expect(undoBtn(container)).not.toBeDisabled();
 
       fireEvent.click(undoBtn(container));

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -131,6 +131,11 @@ const messages = {
     youtubePlay: 'Play',
     youtubePause: 'Pause',
     youtubeReturnToZoom: 'Return to canvas zoom',
+
+    // Lazy chunk load failure (e.g. transient network error or stale tab
+    // referencing chunks that were removed by a redeploy)
+    lazyChunkLoadFailed: 'Failed to load this section. Reloading the page usually fixes it.',
+    reload: 'Reload',
   },
   ja: {
     // DrawingPanel
@@ -264,6 +269,10 @@ const messages = {
     youtubePlay: '再生',
     youtubePause: '一時停止',
     youtubeReturnToZoom: 'キャンバスズームに戻る',
+
+    // Lazy chunk load failure
+    lazyChunkLoadFailed: 'この機能の読み込みに失敗しました。ページを再読み込みすると通常は解決します。',
+    reload: '再読み込み',
   },
 } as const;
 


### PR DESCRIPTION
## Summary

Resolve Vite's `Some chunks are larger than 500 kB` warning by code-splitting the three heaviest on-demand components via `React.lazy` + `Suspense`. Each is only mounted after a user action that already involves a network fetch (Gallery → DB scan, Sketchfab → iframe load, Pexels → API call), so the Suspense fallback (`CircularProgress`) blends with the existing wait.

### Build output

| Chunk | Before | After |
|---|---|---|
| main `index` | **712.19 kB** (gzip 220.69 kB) | **372.52 kB** (gzip 112.04 kB) |
| `storage` (auto-split) | — | 304.60 kB (gzip 100.54 kB) |
| `Gallery` | (in main) | 17.51 kB (gzip 6.42 kB) |
| `SketchfabViewer` | (in main) | 9.73 kB (gzip 3.82 kB) |
| `PexelsSearcher` | (in main) | 6.16 kB (gzip 2.46 kB) |
| `ToggleButtonGroup` (auto-split) | — | 6.02 kB (gzip 1.94 kB) |

The 500 kB warning is gone. Users who never open Gallery / Sketchfab / Pexels now skip those chunks entirely.

### Implementation notes

- `Gallery` lazy mount lives in `DrawingPanel`, with a full-screen overlay fallback matching the modal it replaces.
- `SketchfabViewer` and `PexelsSearcher` lazy mounts live in `ReferencePanel`, sharing a panel-centered `LazyPanelFallback` (consistent with `ui-design-principles.md` §5).
- Type-only imports of `SketchfabActions` / `SketchfabFixAngleExtras` / `SketchfabModelMeta` stay eager (no runtime cost) so `ReferencePanel` and `SplitLayout` keep their existing typing without forcing the chunk to load.
- YouTubeViewer / ImageViewer / PexelsApiKeyDialog remain eager — they're either lighter or always-needed once a source is active.

### Test changes

Two existing tests asserted on lazy-loaded DOM synchronously and have been switched to async queries that await the Suspense boundary:
- `DrawingPanel.test.tsx` — `getByTestId('gallery-stub')` → `await findByTestId('gallery-stub')`
- `SplitLayout.test.tsx` — `getByPlaceholderText(/Search photos/i)` → `await screen.findByPlaceholderText(...)`

The Sketchfab equivalent test passes unchanged because it never asserts on inner Sketchfab DOM, only on the source-selection UI being replaced.

## Test plan

- [x] `npm run build` — chunk-size warning gone, three new lazy chunks emitted
- [x] `npm run test` — 28 files / 418 tests pass, no act() warnings
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)