### PR TITLE
ci: parallelize build/lint/test and share dist artifact for faster PR preview

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,13 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      # workflow_dispatch lacks a diff base for paths-filter, so force-run all jobs.
+      code: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      - if: github.event_name != 'workflow_dispatch'
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
               - '.github/workflows/test.yml'
 
   build:
-    name: Build and Lint
+    name: Build
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.code == 'true'
@@ -56,14 +56,54 @@ jobs:
           cache: npm
 
       - run: npm ci
-      - run: npm run build
+      - name: Build
+        run: npm run build -- --base=${{ github.event_name == 'pull_request' && format('/drawing-practice/pr/{0}/', github.event.pull_request.number) || '/drawing-practice/' }}
+
+      - name: Upload PR preview artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-preview-dist
+          path: dist
+          retention-days: 1
+          if-no-files-found: error
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
       - run: npm run lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
       - run: npm run test
 
   ci-summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [changes, build]
+    needs: [changes, build, lint, test]
     if: always()
 
     steps:
@@ -71,6 +111,8 @@ jobs:
         run: |
           echo "Code changes: ${{ needs.changes.outputs.code }}"
           echo "Build result: ${{ needs.build.result }}"
+          echo "Lint result:  ${{ needs.lint.result }}"
+          echo "Test result:  ${{ needs.test.result }}"
 
           if [[ "${{ needs.changes.outputs.code }}" == "true" ]]; then
             echo "Tests were executed. Checking results..."
@@ -102,17 +144,11 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Download PR preview artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          node-version: 22
-          cache: npm
-
-      - run: npm ci
-
-      - name: Build PR preview
-        run: npm run build -- --base=/drawing-practice/pr/${{ github.event.pull_request.number }}/
+          name: pr-preview-dist
+          path: dist
 
       - name: Deploy PR Preview
         uses: koizuka/pr-preview-action@b03654e20a3e1a9c84309ac9a864e6ba3c4d078b # v1.1.1


### PR DESCRIPTION
## Summary

- `build` ジョブを `build` / `lint` / `test` の3並列ジョブに分割。
- `build` は最初から PR 用 `--base=/drawing-practice/pr/<PR>/` でビルドして `dist` を artifact として upload (retention 1日)。`pr-preview` はそれを download してデプロイのみ行う (`npm ci` / `npm run build` 撤去)。
- `pr-preview` は `lint`/`test` の結果を待たない (失敗しても preview は公開される)。マージガードは `ci-summary` が `[changes, build, lint, test]` を集約するので従来どおり全グリーンが必要。
- `pr-preview` の `actions/checkout` も削除 (`koizuka/pr-preview-action` 内部で gh-pages を独自 clone するため不要; `pr-cleanup.yml` も checkout なしで稼働中)。
- `build` は `format()` 式で PR base / 本番 base を 1 ステップに集約。`workflow_dispatch` 経路の base が `gh-pages.yml` と一致 (`/drawing-practice/`) するようになった。

期待効果: PR push から Preview 公開まで **~5 分 → ~2 分**。

新規追加した actions は SHA pin 済み:
- `actions/upload-artifact@v7.0.1`
- `actions/download-artifact@v8.0.1`

## Test plan

このPR自体が新パイプラインの動作確認用です。Actions タブで以下を確認:

- [x] `changes` 完了直後に `build` / `lint` / `test` が**同時開始**する <sub>(run 25393315001: changes 完了 17:59:58 → build/lint/test 18:00:02-03 に並列開始)</sub>
- [x] `build` 完了直後 (lint/test 進行中でも) に `pr-preview` が開始される <sub>(build 完了 18:00:20 → pr-preview 開始 18:00:30, test は 18:00:42 まで継続中)</sub>
- [x] `pr-preview` ステップに `npm ci` / `npm run build` が**含まれない** (artifact DL のみ) <sub>(ジョブステップ: Set up / Download PR preview artifact / Deploy PR Preview / Complete のみ)</sub>
- [x] `pr-preview` に `actions/checkout` ステップがない
- [x] PR Preview の IndexedDB 名 `DrawingPracticeDB_/drawing-practice/pr/152/` で main と分離されており、main 訪問時に `cleanupStalePrDatabases()` で正しく削除される
- [x] `ci-summary` が build/lint/test 全グリーンで成功する

実測: push → preview 公開まで約85秒 (見積 ~2分より高速)。pr-preview ジョブ単体は44秒。

(別途、別PRで lint または test を意図的に壊して `pr-preview` がそれでもデプロイされ `ci-summary` が赤になる挙動を後日確認予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)