### PR TITLE
chore: react-doctor low-risk cleanup (score 83→88)

### DIFF
--- a/.claude/rules/reference-sources.md
+++ b/.claude/rules/reference-sources.md
@@ -53,7 +53,7 @@ Two overlay modes:
 - **Zoom mode (default)**: `pointer-events: auto`, captures wheel/trackpad/2-finger pinch and drives shared `ViewTransform`. **Why:** prevents browser page-zoom default on `ctrlKey` wheel or iframe pinch. Single tap auto-promotes to video mode.
 - **Video interact mode**: `pointer-events: none` so iframe handles clicks (seek bar, subtitles, settings). Exited via toolbar button in `ReferencePanel`.
 
-Play/pause via YouTube IFrame Player API (`enablejsapi=1` + postMessage; see `YT_EVENT_*` / `YT_CMD_*`). `YouTubeViewer` is `forwardRef` exposing `YouTubePlayerHandle` (`{ play(), pause() }`). Emits `onPlayerStateChange(isPlaying)` with per-transition de-dup (`lastPlayingRef`) so the toolbar icon flips without thrash.
+Play/pause via YouTube IFrame Player API (`enablejsapi=1` + postMessage; see `YT_EVENT_*` / `YT_CMD_*`). `YouTubeViewer` accepts a `ref` prop (React 19+ ref-as-prop pattern) exposing `YouTubePlayerHandle` (`{ play(), pause() }`). Emits `onPlayerStateChange(isPlaying)` with per-transition de-dup (`lastPlayingRef`) so the toolbar icon flips without thrash.
 
 **No video-frame capture** — YouTube iframe content is CORS-protected. Fix/still-frame is intentionally unsupported. **Why:** cross-origin iframe isolation makes wheel/touch events inside the iframe unreachable from the parent; the overlay-and-tap model is the deliberate workaround.
 

--- a/src/components/YouTubeViewer.tsx
+++ b/src/components/YouTubeViewer.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback, useState, forwardRef, useImperativeHandle } from 'react';
+import { useRef, useEffect, useCallback, useState, useImperativeHandle, type Ref } from 'react';
 import { Box } from '@mui/material';
 import { buildYouTubeEmbedUrl, YOUTUBE_ORIGIN } from '../utils/youtube';
 import { drawGrid, drawGuideLines } from '../guides/drawGuides';
@@ -74,9 +74,10 @@ interface YouTubeViewerProps {
   onRequestVideoInteract?: () => void;
   /** Emits true when the player starts playing, false when it pauses/ends. */
   onPlayerStateChange?: (isPlaying: boolean) => void;
+  ref?: Ref<YouTubePlayerHandle>;
 }
 
-export const YouTubeViewer = forwardRef<YouTubePlayerHandle, YouTubeViewerProps>(function YouTubeViewer({
+export function YouTubeViewer({
   videoId, grid, guideLines, guideVersion,
   overlayStrokes, overlayCurrentStrokeRef, onRegisterOverlayRedraw,
   onFitSize,
@@ -86,7 +87,8 @@ export const YouTubeViewer = forwardRef<YouTubePlayerHandle, YouTubeViewerProps>
   videoInteractMode = false,
   onRequestVideoInteract,
   onPlayerStateChange,
-}, ref) {
+  ref,
+}: YouTubeViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -644,4 +646,4 @@ export const YouTubeViewer = forwardRef<YouTubePlayerHandle, YouTubeViewerProps>
       />
     </Box>
   );
-});
+}

--- a/src/components/galleryGrouping.ts
+++ b/src/components/galleryGrouping.ts
@@ -23,7 +23,7 @@ export function persistGroupMode(mode: GroupMode): void {
 
 const monthFormatter = new Intl.DateTimeFormat(undefined, { year: 'numeric', month: 'long' });
 
-export function formatYearMonth(date: Date): string {
+function formatYearMonth(date: Date): string {
   return monthFormatter.format(date);
 }
 

--- a/src/drawing/StrokeManager.ts
+++ b/src/drawing/StrokeManager.ts
@@ -330,9 +330,11 @@ export class StrokeManager {
   }
 
   getRedoStack(): readonly Stroke[] {
-    return this.redoStack
-      .filter((e): e is RedoEntry & { type: 'add' } => e.type === 'add')
-      .map(e => e.stroke);
+    const result: Stroke[] = [];
+    for (const e of this.redoStack) {
+      if (e.type === 'add') result.push(e.stroke);
+    }
+    return result;
   }
 
   clear(): void {

--- a/src/drawing/index.ts
+++ b/src/drawing/index.ts
@@ -1,7 +1,0 @@
-export { StrokeManager } from './StrokeManager';
-export { CanvasRenderer } from './CanvasRenderer';
-export { ViewTransform } from './ViewTransform';
-export type { Point, Stroke } from './types';
-export type { Transform, ContainerSize } from './ViewTransform';
-export type { CanvasRendererOptions } from './CanvasRenderer';
-export { STROKE_WIDTH, OVERLAY_HALO_MULTIPLIER } from './constants';

--- a/src/drawing/quantize.ts
+++ b/src/drawing/quantize.ts
@@ -8,7 +8,7 @@ const QUANTIZE_FACTOR = 10;
  * halves (Math.round(0.5) === 1, Math.round(-0.5) === 0), which would shift
  * strokes toward the origin asymmetrically once world coords can be negative.
  */
-export function quantize(v: number): number {
+function quantize(v: number): number {
   const sign = v < 0 ? -1 : 1;
   return sign * Math.round(Math.abs(v) * QUANTIZE_FACTOR) / QUANTIZE_FACTOR;
 }

--- a/src/guides/index.ts
+++ b/src/guides/index.ts
@@ -1,5 +1,0 @@
-export { GuideManager } from './GuideManager';
-export { GuideProvider } from './GuideContext';
-export { useGuides } from './useGuides';
-export { DEFAULT_GUIDE_STATE, migrateGridSettings } from './types';
-export type { GuideLine, GridSettings, GridMode, GuideState } from './types';

--- a/src/guides/types.ts
+++ b/src/guides/types.ts
@@ -22,8 +22,6 @@ export const DEFAULT_GUIDE_STATE: GuideState = {
   lines: [],
 };
 
-export const NORMAL_GRID_SPACING = 100;
-
 const GRID_SPACINGS: Record<GridMode, number> = {
   none: 0,
   normal: 100,

--- a/src/hooks/useSessionLock.ts
+++ b/src/hooks/useSessionLock.ts
@@ -38,6 +38,7 @@ export function useSessionLock(): SessionLockStatus {
     if (!supportsLocks) return;
 
     let unmounted = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
     function tryAcquire(retriesLeft: number) {
       navigator.locks.request(LOCK_NAME, { ifAvailable: true }, (lock) => {
@@ -46,7 +47,10 @@ export function useSessionLock(): SessionLockStatus {
         }
         if (!lock) {
           if (retriesLeft > 0) {
-            setTimeout(() => tryAcquire(retriesLeft - 1), RETRY_DELAY_MS);
+            retryTimer = setTimeout(() => {
+              retryTimer = null;
+              tryAcquire(retriesLeft - 1);
+            }, RETRY_DELAY_MS);
           }
           else {
             setStatus('denied');
@@ -66,6 +70,10 @@ export function useSessionLock(): SessionLockStatus {
 
     return () => {
       unmounted = true;
+      if (retryTimer !== null) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
       releaseRef.current?.();
     };
   }, []);

--- a/src/storage/drawingStore.ts
+++ b/src/storage/drawingStore.ts
@@ -35,14 +35,6 @@ export async function getAllDrawings(): Promise<DrawingRecord[]> {
   return await db.drawings.orderBy('createdAt').reverse().toArray();
 }
 
-export async function getDrawing(id: number): Promise<DrawingRecord | undefined> {
-  return await db.drawings.get(id);
-}
-
 export async function deleteDrawing(id: number): Promise<void> {
   await db.drawings.delete(id);
-}
-
-export async function getDrawingCount(): Promise<number> {
-  return await db.drawings.count();
 }

--- a/src/storage/exportDrawing.ts
+++ b/src/storage/exportDrawing.ts
@@ -199,7 +199,7 @@ const EXPORTERS: Record<ExportFormat, (d: DrawingRecord) => Blob | Promise<Blob>
   jpeg: exportDrawingAsJpeg,
 };
 
-export function triggerDownload(blob: Blob, filename: string): void {
+function triggerDownload(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;

--- a/src/storage/exportDrawing.ts
+++ b/src/storage/exportDrawing.ts
@@ -126,11 +126,11 @@ export function pointsToPathData(stroke: Stroke): string {
 export function exportDrawingAsSvg(drawing: DrawingRecord): Blob {
   const box = paddedBox(computeStrokesBoundingBox(drawing.strokes));
   const viewBox = `${formatNum(box.x)} ${formatNum(box.y)} ${formatNum(box.width)} ${formatNum(box.height)}`;
-  const paths = drawing.strokes
-    .map(s => pointsToPathData(s))
-    .filter(d => d.length > 0)
-    .map(d => `<path d="${d}"/>`)
-    .join('');
+  let paths = '';
+  for (const s of drawing.strokes) {
+    const d = pointsToPathData(s);
+    if (d.length > 0) paths += `<path d="${d}"/>`;
+  }
   const svg
     = `<?xml version="1.0" encoding="UTF-8"?>`
       + `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}" width="${formatNum(box.width)}" height="${formatNum(box.height)}">`

--- a/src/storage/historyEviction.ts
+++ b/src/storage/historyEviction.ts
@@ -10,8 +10,8 @@ export function selectKeysToEvict<T, K>(
   getTime: (row: T) => number,
 ): K[] {
   if (rows.length <= limit) return [];
-  return [...rows]
-    .sort((a, b) => getTime(a) - getTime(b))
+  return rows
+    .toSorted((a, b) => getTime(a) - getTime(b))
     .slice(0, rows.length - limit)
     .map(getKey);
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,10 +1,8 @@
-export { saveDrawing, getAllDrawings, getDrawing, deleteDrawing, getDrawingCount } from './drawingStore';
-export { saveDraft, loadDraft, clearDraft } from './sessionStore';
-export { addUrlHistory, getUrlHistory, getUrlHistoryEntry, deleteUrlHistory, URL_HISTORY_LIMIT, URL_HISTORY_IMAGE_LIMIT } from './urlHistoryStore';
+export { saveDrawing, getAllDrawings, deleteDrawing } from './drawingStore';
+export { addUrlHistory, getUrlHistory, getUrlHistoryEntry, deleteUrlHistory } from './urlHistoryStore';
 export type { AddUrlHistoryOptions } from './urlHistoryStore';
-export { addPexelsSearchHistory, getPexelsSearchHistory, deletePexelsSearchHistory, PEXELS_SEARCH_HISTORY_LIMIT } from './pexelsSearchHistoryStore';
-export { addSketchfabSearchHistory, getSketchfabSearchHistory, deleteSketchfabSearchHistory, SKETCHFAB_SEARCH_HISTORY_LIMIT } from './sketchfabSearchHistoryStore';
+export { addPexelsSearchHistory, getPexelsSearchHistory, deletePexelsSearchHistory } from './pexelsSearchHistoryStore';
+export { addSketchfabSearchHistory, getSketchfabSearchHistory, deleteSketchfabSearchHistory } from './sketchfabSearchHistoryStore';
 export { computeStorageUsage, formatBytes } from './storageUsage';
 export type { StorageUsage } from './storageUsage';
-export type { DrawingRecord, SessionDraft, UrlHistoryEntry, UrlHistoryType, PexelsSearchHistoryEntry, SketchfabSearchHistoryEntry } from './db';
-export type { DraftData } from './sessionStore';
+export type { DrawingRecord, UrlHistoryEntry, UrlHistoryType, PexelsSearchHistoryEntry, SketchfabSearchHistoryEntry } from './db';

--- a/src/storage/pexelsSearchHistoryStore.ts
+++ b/src/storage/pexelsSearchHistoryStore.ts
@@ -2,7 +2,7 @@ import { db, type PexelsSearchHistoryEntry } from './db';
 import { selectKeysToEvict } from './historyEviction';
 import type { PexelsOrientationFilter } from '../utils/pexels';
 
-export const PEXELS_SEARCH_HISTORY_LIMIT = 50;
+const PEXELS_SEARCH_HISTORY_LIMIT = 50;
 
 /**
  * Upsert a search history entry. Deduped by lowercased trimmed query so

--- a/src/storage/sketchfabSearchHistoryStore.ts
+++ b/src/storage/sketchfabSearchHistoryStore.ts
@@ -2,7 +2,7 @@ import { db, type SketchfabSearchHistoryEntry } from './db';
 import { selectKeysToEvict } from './historyEviction';
 import type { SketchfabCategorySlug, SketchfabTimeFilter } from '../utils/sketchfab';
 
-export const SKETCHFAB_SEARCH_HISTORY_LIMIT = 50;
+const SKETCHFAB_SEARCH_HISTORY_LIMIT = 50;
 
 function makeKey(query: string, category?: SketchfabCategorySlug): string {
   return `${query.trim().toLowerCase()}|${category ?? ''}`;

--- a/src/utils/imageResize.ts
+++ b/src/utils/imageResize.ts
@@ -1,6 +1,6 @@
 export const HISTORY_IMAGE_MAX_EDGE = 2048;
-export const HISTORY_IMAGE_PASSTHROUGH_SIZE = 1.5 * 1024 * 1024;
-export const HISTORY_IMAGE_JPEG_QUALITY = 0.85;
+const HISTORY_IMAGE_PASSTHROUGH_SIZE = 1.5 * 1024 * 1024;
+const HISTORY_IMAGE_JPEG_QUALITY = 0.85;
 
 /**
  * Compute the scaled dimensions that fit within maxEdge on the longest side

--- a/src/utils/pexels.ts
+++ b/src/utils/pexels.ts
@@ -12,7 +12,7 @@ export interface PexelsLastSearch {
   orientation: PexelsOrientationFilter;
 }
 
-export interface PexelsPhotoSrc {
+interface PexelsPhotoSrc {
   original: string;
   large2x: string;
   large: string;


### PR DESCRIPTION
## Summary

react-doctor が指摘した警告のうち、**安全に修正できるもののみ** に絞ってクリーンアップ。

| | スコア | 警告数 | 影響ファイル数 |
|---|---|---|---|
| Before | 83/100 | 97 | 31/90 |
| **After** | **88/100** | **69** | **17/88** |

Dead Code カテゴリは **21 → 0** 件で完全消滅。

### 修正内容

- **バグ修正**: `useSessionLock` の `setTimeout` クリーンアップ漏れ(react-doctor で唯一の error severity)
- **React 19 対応**: `YouTubeViewer` を `forwardRef` から ref-as-prop パターンへ移行
- **デッドコード削除**:
  - 未使用の barrel ファイル(`src/drawing/index.ts`, `src/guides/index.ts`)
  - 未使用の関数 `getDrawing` / `getDrawingCount`
  - 未使用の定数 `NORMAL_GRID_SPACING`
  - `src/storage/index.ts` の未使用 re-export
  - 内部のみで使われる7つのシンボルから `export` キーワードを除去(`formatYearMonth`, `triggerDownload`, `HISTORY_IMAGE_PASSTHROUGH_SIZE`, `HISTORY_IMAGE_JPEG_QUALITY`, `quantize`, `PEXELS_SEARCH_HISTORY_LIMIT`, `SKETCHFAB_SEARCH_HISTORY_LIMIT`)
  - `PexelsPhotoSrc` 型の export 降格
- **マイクロ最適化**:
  - `[...arr].sort()` → `arr.toSorted()` (ES2023)
  - `.filter().map()` チェーンを単一ループに統合(`StrokeManager.getRedoStack`, `exportDrawingAsSvg`)

### ドキュメント更新

- `.claude/rules/reference-sources.md`: `YouTubeViewer` の ref パターン記述を更新

## あえて見送った警告(残り69件のリスク評価)

| カテゴリ | 件数 | 見送り理由 |
|---|---|---|
| `rerender-state-only-in-handlers` | 10 | **全て false positive**。React 公式推奨の prev-prop tracking、または callback/effect deps として使用中(useRef 化すると closure 更新が壊れる) |
| `no-giant-component` / `prefer-useReducer` | 14 | プロジェクト固有の不変条件(camera共有、autosave連動など)を壊すリスク。個別レビューで対処すべき |
| `js-batch-dom-css` | 7 | `cssText` 化は CSP / typing 面で利点が薄い |
| `client-passive-event-listeners` | 7 | 大半が `event.preventDefault()` 呼び出し済み。`passive: true` は意図的動作(ページズーム抑止、stroke gesture)を破壊 |
| `prefer-use-effect-event` | 6 | 既存の `requestRedrawRef` ref パターンと併存になりリスクに見合わない |
| `no-cascading-set-state` | 6 | `loadDraft` の17 setState は restore シーケンスとして意図的 |
| `no-prop-callback-in-effect` | 6 | 親への状態通知は `onStateChange` 等の意図的な API 設計 |
| `rendering-hydration-mismatch-time` | 3 | Vite SPA(SSR なし)で **完全な誤検知** |
| `client-localstorage-no-version` | 2 | テストファイル内のモックキー |
| `server-sequential-independent-await` | 2 | テストファイル内。Server コードではない誤検知 |
| `no-react19-deprecated-apis (useContext)` | 1 | `useContext` は非推奨ではない。条件分岐なし読みなので `use()` 置換メリットなし |
| `no-autofocus` | 1 | Dialog の primary input。意図的な UX |
| `no-derived-useState` / `no-effect-event-handler` | 2 | prev-prop tracking パターンとして意図的 |
| `advanced-event-handler-refs` | 2 | useEffectEvent 系と同様、リスクに見合わない |

## Test plan

- [x] `npm run lint` パス
- [x] `npm run test` パス(460 tests)
- [x] `npm run build` パス
- [ ] iPad Safari で描画パネル / リファレンスパネルの基本動作を確認
- [x] YouTube リファレンスの play/pause トグルが動作する(forwardRef 移行の確認)
- [x] セッションロック(2タブ目を開く→ "another tab" Alert が出る)

🤖 Generated with [Claude Code](https://claude.com/claude-code)