### PR TITLE
chore(ci): .nvmrc 変更を workflow trigger と npm cache key に反映

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,7 @@ on:
       - 'tsconfig*.json'
       - 'vite.config.ts'
       - 'eslint.config.js'
+      - '.nvmrc'
       - '.github/workflows/gh-pages.yml'
 
   workflow_dispatch:
@@ -33,6 +34,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            .nvmrc
 
       - run: npm ci
       - run: npm run build -- --base=/drawing-practice/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
               - 'src/**'
               - 'tsconfig*.json'
               - 'eslint.config.js'
+              - '.nvmrc'
               - '.github/workflows/test.yml'
 
   build:
@@ -55,6 +56,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            .nvmrc
 
       - run: npm ci
       - name: Build
@@ -81,6 +85,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            .nvmrc
 
       - run: npm ci
       - run: npm run lint
@@ -97,6 +104,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            .nvmrc
 
       - run: npm ci
       - run: npm run test


### PR DESCRIPTION
## Summary

`.nvmrc` で Node バージョンを一元管理しているが、`.nvmrc` を変更したときの CI 反映が不完全だったので 2 点を修正。

- **トリガ漏れ**: `gh-pages.yml` の push `paths` と `test.yml` の `dorny/paths-filter` の `code` フィルタに `.nvmrc` を追加。これがないと `.nvmrc` だけの PR で build / lint / test がスキップされ、main マージ後の gh-pages デプロイも走らないため、新しい Node バージョンが CI で検証できなかった。
- **cache key 漏れ**: `actions/setup-node` の組み込み cache key は `cache-dependency-path` のハッシュのみで構成され、`node-version-file` は反映されない。`cache-dependency-path` に `package-lock.json` と `.nvmrc` を併記することで、Node バージョン更新時に npm cache が確実にミスして再構築される。

`audit` ジョブは `cache:` 未指定 (`--package-lock-only` で install しない) のため変更不要。

## Test plan

- [x] `npm run lint` パス
- [x] `npm run build` パス
- [x] この PR の CI が build / lint / test すべて成功すること
- [ ] (次回 Node バージョン更新 PR で) `.nvmrc` 改変時に paths-filter が `code=true` を返し、setup-node の cache key が前回と異なる (cache miss) ことをログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)