### PR TITLE
Fix stale iPad Safari touch sessions blocking Pencil strokes

### DIFF
--- a/src/components/DrawingCanvas.test.tsx
+++ b/src/components/DrawingCanvas.test.tsx
@@ -1,0 +1,159 @@
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DrawingCanvas } from './DrawingCanvas';
+import { StrokeManager } from '../drawing/StrokeManager';
+import type { GridSettings } from '../guides/types';
+
+const grid: GridSettings = { mode: 'none' };
+
+const CANVAS_RECT: DOMRect = {
+  left: 0,
+  top: 0,
+  right: 400,
+  bottom: 300,
+  width: 400,
+  height: 300,
+  x: 0,
+  y: 0,
+  toJSON: () => ({}),
+};
+
+let originalResizeObserver: typeof globalThis.ResizeObserver;
+
+function touch(identifier: number, clientX: number, clientY: number): Touch {
+  return { identifier, clientX, clientY, touchType: 'stylus' } as Touch & { touchType: string };
+}
+
+function renderCanvas(strokeManager = new StrokeManager()) {
+  const onStrokeCountChange = vi.fn();
+  const view = render(
+    <DrawingCanvas
+      mode="pen"
+      highlightedStrokeIndex={null}
+      onHighlightStroke={vi.fn()}
+      onStrokeCountChange={onStrokeCountChange}
+      strokeManager={strokeManager}
+      redrawVersion={0}
+      viewResetVersion={0}
+      grid={grid}
+      guideLines={[]}
+      guideVersion={0}
+    />,
+  );
+  return {
+    ...view,
+    canvas: view.container.querySelector('canvas')!,
+    onStrokeCountChange,
+    strokeManager,
+  };
+}
+
+beforeEach(() => {
+  originalResizeObserver = globalThis.ResizeObserver;
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(CANVAS_RECT);
+  globalThis.ResizeObserver = class ResizeObserver {
+    private cb: ResizeObserverCallback;
+
+    constructor(cb: ResizeObserverCallback) {
+      this.cb = cb;
+    }
+
+    observe(target: Element) {
+      this.cb([{ target, contentRect: CANVAS_RECT } as ResizeObserverEntry], this);
+    }
+
+    unobserve() {}
+    disconnect() {}
+  } as typeof globalThis.ResizeObserver;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.ResizeObserver = originalResizeObserver;
+  vi.restoreAllMocks();
+});
+
+describe('DrawingCanvas touch recovery', () => {
+  it('drops stale active touches on the next touchstart so Pencil strokes do not get stuck as pinch gestures', () => {
+    const { canvas, strokeManager, onStrokeCountChange } = renderCanvas();
+
+    // Start a Pencil stroke, then simulate iOS Safari losing the matching
+    // touchend/touchcancel. The old touch id remains only in app state.
+    fireEvent.touchStart(canvas, {
+      touches: [touch(1, 20, 20)],
+      changedTouches: [touch(1, 20, 20)],
+    });
+    fireEvent.touchMove(canvas, {
+      touches: [touch(1, 30, 30)],
+      changedTouches: [touch(1, 30, 30)],
+    });
+
+    // The next touchstart's `touches` list contains only the new live Pencil
+    // contact. Rebuilding from that list must discard the stale id; otherwise
+    // this would arm pinch mode and never commit a stroke.
+    fireEvent.touchStart(canvas, {
+      touches: [touch(2, 80, 80)],
+      changedTouches: [touch(2, 80, 80)],
+    });
+    fireEvent.touchMove(canvas, {
+      touches: [touch(2, 110, 110)],
+      changedTouches: [touch(2, 110, 110)],
+    });
+    fireEvent.touchEnd(canvas, {
+      touches: [],
+      changedTouches: [touch(2, 110, 110)],
+    });
+
+    expect(strokeManager.getStrokes()).toHaveLength(1);
+    expect(onStrokeCountChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears an in-flight touch session on page blur', () => {
+    const { canvas, strokeManager } = renderCanvas();
+
+    fireEvent.touchStart(canvas, {
+      touches: [touch(1, 20, 20)],
+      changedTouches: [touch(1, 20, 20)],
+    });
+    fireEvent.touchMove(canvas, {
+      touches: [touch(1, 30, 30)],
+      changedTouches: [touch(1, 30, 30)],
+    });
+
+    window.dispatchEvent(new Event('blur'));
+
+    expect(strokeManager.getCurrentStroke()).toBeNull();
+  });
+
+  it('clears stale pinch state when the next touchstart has only one live touch', () => {
+    const { canvas, strokeManager, onStrokeCountChange } = renderCanvas();
+
+    fireEvent.touchStart(canvas, {
+      touches: [touch(1, 20, 20), touch(2, 80, 80)],
+      changedTouches: [touch(1, 20, 20), touch(2, 80, 80)],
+    });
+    fireEvent.touchMove(canvas, {
+      touches: [touch(1, 15, 15), touch(2, 85, 85)],
+      changedTouches: [touch(1, 15, 15), touch(2, 85, 85)],
+    });
+
+    // Simulate Safari losing the touchend/touchcancel for the pinch. The next
+    // Pencil contact reports a single live touch, so stale pinch ids must be
+    // cleared before moves are handled.
+    fireEvent.touchStart(canvas, {
+      touches: [touch(3, 120, 120)],
+      changedTouches: [touch(3, 120, 120)],
+    });
+    fireEvent.touchMove(canvas, {
+      touches: [touch(3, 150, 150)],
+      changedTouches: [touch(3, 150, 150)],
+    });
+    fireEvent.touchEnd(canvas, {
+      touches: [],
+      changedTouches: [touch(3, 150, 150)],
+    });
+
+    expect(strokeManager.getStrokes()).toHaveLength(1);
+    expect(onStrokeCountChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -386,6 +386,63 @@ export function DrawingCanvas({
     requestRedraw();
   }, [stopMarching, requestRedraw]);
 
+  const syncActiveTouchesFromEvent = useCallback((e: TouchEvent) => {
+    // `event.touches` is the browser's current active-touch set. Rebuilding
+    // from it on touchstart protects us from iOS Safari occasionally missing
+    // a prior touchend/touchcancel, which otherwise leaves a stale id in the
+    // map and makes every later single Pencil stroke look like a two-finger
+    // pinch. Tests that synthesize only `changedTouches` fall back to the
+    // incremental path below.
+    if (e.touches.length > 0) {
+      activeTouchesRef.current.clear();
+      for (let i = 0; i < e.touches.length; i++) {
+        const touch = e.touches[i];
+        activeTouchesRef.current.set(touch.identifier, { x: touch.clientX, y: touch.clientY });
+      }
+      return;
+    }
+
+    for (let i = 0; i < e.changedTouches.length; i++) {
+      const touch = e.changedTouches[i];
+      activeTouchesRef.current.set(touch.identifier, { x: touch.clientX, y: touch.clientY });
+    }
+  }, []);
+
+  const clearStalePinchAfterTouchSync = useCallback(() => {
+    const pinch = pinchRef.current;
+    if (!pinch) return;
+    if (activeTouchesRef.current.size < 2
+      || !activeTouchesRef.current.has(pinch.id1)
+      || !activeTouchesRef.current.has(pinch.id2)) {
+      pinchRef.current = null;
+      pinchRectRef.current = null;
+    }
+  }, []);
+
+  const resetTouchSession = useCallback(() => {
+    const hadCurrentStroke = Boolean(strokeManager.getCurrentStroke());
+    const hadLasso = Boolean(lassoPointsRef.current);
+    const hadTouchState = activeTouchesRef.current.size > 0 || Boolean(pinchRef.current);
+
+    activeTouchesRef.current.clear();
+    pinchRef.current = null;
+    pinchRectRef.current = null;
+
+    if (hadCurrentStroke) {
+      strokeManager.cancelStroke();
+      onCurrentStrokeChange?.(null);
+    }
+    if (hadLasso) {
+      lassoPointsRef.current = null;
+      lassoBboxRef.current = null;
+      lassoSelectedRef.current = null;
+      stopMarching();
+    }
+    if (hadCurrentStroke || hadLasso || hadTouchState) {
+      requestRedraw();
+    }
+  }, [strokeManager, onCurrentStrokeChange, stopMarching, requestRedraw]);
+
   /** Begin a new lasso path at the given world-space point. */
   const startLasso = useCallback((point: Point) => {
     lassoPointsRef.current = [point];
@@ -530,11 +587,8 @@ export function DrawingCanvas({
     // touch behavior (scroll, etc.).
     if (inputFrozenRef.current) return;
 
-    // Track all touches
-    for (let i = 0; i < e.changedTouches.length; i++) {
-      const touch = e.changedTouches[i];
-      activeTouchesRef.current.set(touch.identifier, { x: touch.clientX, y: touch.clientY });
-    }
+    syncActiveTouchesFromEvent(e);
+    clearStalePinchAfterTouchSync();
 
     // Detect stylus
     for (let i = 0; i < e.changedTouches.length; i++) {
@@ -605,7 +659,7 @@ export function DrawingCanvas({
       onStrokeStart?.();
       strokeManager.startStroke(point);
     }
-  }, [mode, getCanvasPoint, onHighlightStroke, onDeleteHighlightedStroke, highlightedStrokeIndex, strokeManager, getCurrentScale, onCurrentStrokeChange, requestRedraw, startMarching, cancelLasso, startLasso, onStrokeStart]);
+  }, [mode, getCanvasPoint, onHighlightStroke, onDeleteHighlightedStroke, highlightedStrokeIndex, strokeManager, getCurrentScale, onCurrentStrokeChange, requestRedraw, startMarching, cancelLasso, startLasso, onStrokeStart, syncActiveTouchesFromEvent, clearStalePinchAfterTouchSync]);
 
   const handleTouchMove = useCallback((e: TouchEvent) => {
     e.preventDefault();
@@ -751,6 +805,21 @@ export function DrawingCanvas({
       canvas.removeEventListener('touchcancel', onEnd);
     };
   }, []);
+
+  useEffect(() => {
+    const reset = () => resetTouchSession();
+    const resetWhenHidden = () => {
+      if (document.visibilityState === 'hidden') resetTouchSession();
+    };
+    window.addEventListener('blur', reset);
+    window.addEventListener('pagehide', reset);
+    document.addEventListener('visibilitychange', resetWhenHidden);
+    return () => {
+      window.removeEventListener('blur', reset);
+      window.removeEventListener('pagehide', reset);
+      document.removeEventListener('visibilitychange', resetWhenHidden);
+    };
+  }, [resetTouchSession]);
 
   // Mouse fallback handlers
   const isMouseDownRef = useRef(false);


### PR DESCRIPTION
## Summary
- Rebuild active touch state from `event.touches` on `touchstart` so stale iOS Safari touch ids do not keep the drawing canvas stuck in pinch mode
- Reset in-flight touch/pinch/lasso state on blur, pagehide, and hidden visibility transitions
- Add DrawingCanvas tests covering missing touchend/touchcancel recovery and blur cleanup

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- src/components/DrawingCanvas.test.tsx`
- `npm run test`