### PR TITLE
fix(diag): 診断オーバーレイをツールバー直下に下げてボタン操作を回復

### DIFF
--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -145,7 +145,9 @@ export default function TouchDiagnosticsOverlay() {
     return (
       <Box
         sx={{
-          position: 'fixed', top: 8, right: 8, zIndex: 1100,
+          // top: 48 = ツールバー(高さ40px)の直下。top:8 だとドローイングパネル
+          // ツールバー右側のボタン群と重なって押せなくなるため下げる。
+          position: 'fixed', top: 48, right: 8, zIndex: 1100,
           bgcolor: 'rgba(0,0,0,0.75)', color: '#0f0', borderRadius: 1,
           px: 1, py: 0.25, fontFamily: 'monospace', fontSize: '0.7rem',
           display: 'flex', alignItems: 'center', gap: 0.5,
@@ -173,7 +175,9 @@ export default function TouchDiagnosticsOverlay() {
   return (
     <Box
       sx={{
-        position: 'fixed', top: 8, right: 8, zIndex: 1100,
+        // top: 48 = ツールバー(高さ40px)の直下。top:8 だとツールバー右側の
+        // ボタン群と重なって押せなくなるため下げる（畳んだ状態も同様）。
+        position: 'fixed', top: 48, right: 8, zIndex: 1100,
         width: 280, maxHeight: '80dvh',
         display: 'flex', flexDirection: 'column',
         bgcolor: 'rgba(0,0,0,0.82)', color: '#eee', borderRadius: 1,


### PR DESCRIPTION
## 概要

PR #193 で追加した iPad Pencil 入力切り分け診断ハーネス（`?diag=touch`）の HUD オーバーレイ（`TouchDiagnosticsOverlay`）が画面右上 `top: 8, right: 8` に `position: fixed` で固定されており、ドローイングパネルのツールバー（高さ40px）右側のボタン群（グリッド / 反転 / ズームリセット / 全画面 / ギャラリー）と重なって、診断 HUD を表示している間それらのボタンがタップできなくなっていた。畳んだ状態（小さなチップ表示）でも同様。

## 変更内容

- `TouchDiagnosticsOverlay.tsx` の畳んだ状態のチップ・展開状態のパネルの両方で `top: 8` → `top: 48`（ツールバー高さ40px + 8pxマージン）に変更し、ツールバー領域を避けて直下に配置。
- `right: 8` は維持（縦方向の重なりのみが問題のため）。展開時の `maxHeight: '80dvh'` は `top: 48` 起点でも収まる。
- 変更理由をインラインコメントで明記。

一時的な調査用 HUD のため最小限の位置調整に留めている。

## テスト

- `npm run test` — 574 件すべてパス
- `npm run lint` — パス
- `npm run build` — 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the `?diag=touch` HUD (`TouchDiagnosticsOverlay`) below the toolbar to stop covering right-side toolbar buttons and restore taps. Changes `top: 8` to `top: 48` for both collapsed and expanded states; keeps `right: 8` and `maxHeight: '80dvh'` unchanged.

<sup>Written for commit 865457974904f5103d4da0232679966706dfe4e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

