### PR TITLE
fix(diag): 診断オーバーレイをトレーススコア表示の下に下げる

### DIFF
--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -446,7 +446,11 @@ export function DrawingPanel({
   }, []);
 
   return (
-    <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
+    // position: relative は診断オーバーレイ(TouchDiagnosticsOverlay)の
+    // absolute 基準。ビューポート基準(fixed)だと別タブ警告バナーで
+    // ツールバー/キャンバスが下にずれた分を追従できず重なるため、
+    // DrawingPanel を基準にしてレイアウトと一緒に下がるようにする。
+    <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', position: 'relative' }}>
       {/* Toolbar */}
       <Box
         ref={toolbarRef}

--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -145,9 +145,10 @@ export default function TouchDiagnosticsOverlay() {
     return (
       <Box
         sx={{
-          // top: 48 = ツールバー(高さ40px)の直下。top:8 だとドローイングパネル
-          // ツールバー右側のボタン群と重なって押せなくなるため下げる。
-          position: 'fixed', top: 48, right: 8, zIndex: 1100,
+          // top: 84 = ツールバー(高さ40px)の下、さらにトレーススコア表示
+          // (キャンバス内 top:8 の「なぞり済み」オーバーレイ ≒ ビューポート上 48〜76px)
+          // も避けた位置。top:48 だとスコア表示と重なるため下げる。
+          position: 'fixed', top: 84, right: 8, zIndex: 1100,
           bgcolor: 'rgba(0,0,0,0.75)', color: '#0f0', borderRadius: 1,
           px: 1, py: 0.25, fontFamily: 'monospace', fontSize: '0.7rem',
           display: 'flex', alignItems: 'center', gap: 0.5,
@@ -175,9 +176,10 @@ export default function TouchDiagnosticsOverlay() {
   return (
     <Box
       sx={{
-        // top: 48 = ツールバー(高さ40px)の直下。top:8 だとツールバー右側の
-        // ボタン群と重なって押せなくなるため下げる（畳んだ状態も同様）。
-        position: 'fixed', top: 48, right: 8, zIndex: 1100,
+        // top: 84 = ツールバー(高さ40px)の下、さらにトレーススコア表示
+        // (キャンバス内 top:8 の「なぞり済み」オーバーレイ)も避けた位置。
+        // top:48 だとスコア表示と重なるため下げる（畳んだ状態も同様）。
+        position: 'fixed', top: 84, right: 8, zIndex: 1100,
         width: 280, maxHeight: '80dvh',
         display: 'flex', flexDirection: 'column',
         bgcolor: 'rgba(0,0,0,0.82)', color: '#eee', borderRadius: 1,

--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -145,10 +145,12 @@ export default function TouchDiagnosticsOverlay() {
     return (
       <Box
         sx={{
+          // absolute = DrawingPanel(position:relative)基準。fixed だと別タブ
+          // 警告バナーでツールバー/キャンバスが下にずれた分を追従できない。
           // top: 84 = ツールバー(高さ40px)の下、さらにトレーススコア表示
-          // (キャンバス内 top:8 の「なぞり済み」オーバーレイ ≒ ビューポート上 48〜76px)
-          // も避けた位置。top:48 だとスコア表示と重なるため下げる。
-          position: 'fixed', top: 84, right: 8, zIndex: 1100,
+          // (キャンバス内 top:8 の「なぞり済み」オーバーレイ ≒ パネル上端から 48〜76px)
+          // も避けた位置。
+          position: 'absolute', top: 84, right: 8, zIndex: 1100,
           bgcolor: 'rgba(0,0,0,0.75)', color: '#0f0', borderRadius: 1,
           px: 1, py: 0.25, fontFamily: 'monospace', fontSize: '0.7rem',
           display: 'flex', alignItems: 'center', gap: 0.5,
@@ -176,10 +178,11 @@ export default function TouchDiagnosticsOverlay() {
   return (
     <Box
       sx={{
-        // top: 84 = ツールバー(高さ40px)の下、さらにトレーススコア表示
-        // (キャンバス内 top:8 の「なぞり済み」オーバーレイ)も避けた位置。
-        // top:48 だとスコア表示と重なるため下げる（畳んだ状態も同様）。
-        position: 'fixed', top: 84, right: 8, zIndex: 1100,
+        // absolute = DrawingPanel(position:relative)基準。fixed だと別タブ
+        // 警告バナーでツールバー/キャンバスが下にずれた分を追従できない。
+        // top: 84 = ツールバー(高さ40px)の下、トレーススコア表示も避けた位置
+        // （畳んだ状態も同様）。
+        position: 'absolute', top: 84, right: 8, zIndex: 1100,
         width: 280, maxHeight: '80dvh',
         display: 'flex', flexDirection: 'column',
         bgcolor: 'rgba(0,0,0,0.82)', color: '#eee', borderRadius: 1,


### PR DESCRIPTION
## 概要

PR #195 で診断 HUD（`?diag=touch` の `TouchDiagnosticsOverlay`）を `top: 8` → `top: 48` に下げ、ツールバーのボタンとの重なりは解消した。しかしトレース手本を使うとき、キャンバス右上に出る「なぞり済み表示」（トレーススコアオーバーレイ）と新たに重なってしまっていた。

このスコア表示は `DrawingPanel.tsx` でキャンバス領域内に `position: 'absolute', top: 8, right: 8` で配置される。キャンバス領域はツールバー（高さ40px）の直下から始まるため、ビューポート基準では約 `top: 48`〜`76px` の位置になり、診断オーバーレイの `top: 48` とちょうど重なっていた。

## 変更内容

- `TouchDiagnosticsOverlay.tsx` の畳んだ状態のチップ・展開状態のパネルの両方で `top: 48` → `top: 84` に変更し、トレーススコア表示の下に診断 HUD を配置。
- `right: 8` は維持。展開時の `maxHeight: '80dvh'` は `top: 84` 起点でも収まる。
- 変更理由をインラインコメントで更新。

一時的な調査用 HUD のため最小限の位置調整に留めている。

## テスト

- `npm run test` — 579 件すべてパス
- `npm run lint` — パス
- `npm run build` — 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the `?diag=touch` diagnostics HUD below the trace score overlay and anchor it to the `DrawingPanel` so it follows layout shifts (e.g., the autosave warning banner), preventing overlap. Both the collapsed chip and expanded panel now use `position: 'absolute'` with `top: 84` (was 48) and `right: 8` (maxHeight unchanged); `DrawingPanel` is set to `position: 'relative'`.

<sup>Written for commit 918ec55a582a753c0a56a2b51ff704199ea272cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

