### PR TITLE
feat(diag): フリーズ中のカウンタ時系列を自動記録（復旧前の証拠保全）

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -485,7 +485,15 @@ export function DrawingCanvas({
     if (DIAG_ENABLED) {
       diag.resetCount++;
       diag.lastResetTrigger = trigger;
-      logEvent('reset', { trigger, hadCurrentStroke, hadLasso, hadTouchState });
+      // Snapshot the cumulative counters here: a blur/visibility reset is almost
+      // always the user's own recovery gesture (tab/app switch), so this is the
+      // last reading taken *before* the frozen session is cleared. Without it the
+      // post-recovery copy only shows healthy idle state.
+      logEvent('reset', {
+        trigger, hadCurrentStroke, hadLasso, hadTouchState,
+        move: diag.touchmove, docMove: diag.docTouchmove,
+        append: diag.appendOk, redraw: diag.redrawAll, raf: diag.rafTick,
+      });
     }
 
     activeTouchesRef.current.clear();

--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -56,6 +56,11 @@ export default function TouchDiagnosticsOverlay() {
   const prevRef = useRef<typeof diag>({ ...diag });
   // Latch so each stuck episode is logged once at onset, not every tick.
   const stuckRef = useRef(false);
+  // 1Hz activity-gated timeline: counters at the last second-boundary snapshot,
+  // plus a tick counter. Lets us reconstruct the freeze window even when the
+  // user recovers (tab switch) before reading the live counters.
+  const secRef = useRef<typeof diag>({ ...diag });
+  const tickCountRef = useRef(0);
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -108,6 +113,30 @@ export default function TouchDiagnosticsOverlay() {
       }
       else if (!stuck) {
         stuckRef.current = false;
+      }
+
+      // 1Hz activity-gated timeline. Every ~1s, if there was touch activity in
+      // the last second (or a stroke is mid-flight), log a compact counter
+      // snapshot. During a freeze where the user keeps stroking the Pencil this
+      // records whether move/append/redraw/raf advance or flatline — the exact
+      // signal that separates input-drop (A) from compositor-stall (B) — and it
+      // survives the user's recovery tab-switch. Idle seconds log nothing so the
+      // 200-entry ring isn't wasted.
+      if (++tickCountRef.current >= Math.round(1000 / POLL_MS)) {
+        tickCountRef.current = 0;
+        const base = secRef.current;
+        const dMove = cur.touchmove - base.touchmove;
+        const dDoc = cur.docTouchmove - base.docTouchmove;
+        if (dMove > 0 || dDoc > 0 || state?.drawing) {
+          logEvent('tick', {
+            move: dMove, doc: dDoc,
+            append: cur.appendOk - base.appendOk,
+            redraw: cur.redrawAll - base.redrawAll,
+            raf: cur.rafTick - base.rafTick,
+            mode: state?.mode,
+          });
+        }
+        secRef.current = { ...cur };
       }
 
       prevRef.current = { ...cur };


### PR DESCRIPTION
## 背景

iPad Pencil「ストロークが突然無視される」フリーズの**初の実機キャプチャ**が取れたが、解析可能な形ではなかった。ログ末尾は `reset blur/visibility`（＝ユーザーの復旧タブ切替）→ バックグラウンド化による `rafStalled`（想定内ノイズ）→ 247秒の無イベント間隔 → コピー、という流れ。**復旧操作がフリーズ中のカウンタを読む前にセッションをリセットして証拠を消していた。**

キャプチャから確定したこと:
- 入力・データ経路は健全（`startStroke 156` = `endCommit 156`、`appendSkip 0`、`rejInputFrozen 0`）。canvas に届いた stylus は全部 stroke 化・コミット。
- リジェクトは全て `direct`（rX 31〜41＝指/手のひら）の正常なパームリジェクト。

## 変更

復旧操作が証拠を消す前に、フリーズ中の状態を自動で残す:

1. **reset ログに復旧直前の累積カウンタを同梱**（move/docMove/append/redraw/raf）。blur/visibility reset はほぼユーザー自身の復旧操作なので、ここが「フリーズセッションがクリアされる直前」の最後の読み取りになる。
2. **オーバーレイ poll に 1Hz の活動時スナップショット（`tick`）を追加**。直近1秒にタッチ活動があった（or ストローク進行中）ときだけ move/append/redraw/raf のデルタを記録。フリーズ中にペンで描き続けた際に各カウンタが進むか止まるかの時系列を残し、入力脱落(A)とコンポジッタ停止(B)を切り分ける。アイドル秒は記録しない（200件輪バッファを浪費しない）。

## 次回キャプチャ手順（実機）

フリーズが起きたら **タブ切替で復旧する前に**:
1. canvas 上の赤い `#N` ハートビート（番号＋動くドット）が**進んでいるか止まっているか**を目視 → 止まっていれば**コンポジッタ提示停止(B)が確定**。
2. オーバーレイを見ながらペンで5本ほど描き、`start/move` と `append`、`doc move` が増えるか観察。
3. その後 Copy → 復旧。`tick` 時系列が自動で残っているので切替後でも解析可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically preserves freeze diagnostics by logging a 1Hz activity-based counter timeline and a pre-recovery snapshot in `reset`, so evidence survives user tab/app switches. Helps distinguish input drop (A) vs compositor stall (B).

- **New Features**
  - `reset` logs now include cumulative counters: move, docMove, append, redraw, raf (captured right before recovery clears state).
  - Overlay adds a 1Hz activity-gated `tick` that records deltas for move/doc/append/redraw/raf only when there was touch activity or an active stroke, skipping idle seconds.

<sup>Written for commit 65998c18825959859e209703b79bfd3831430ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

