### PR TITLE
feat(diag): フリーズ中の別系統入力(pointer/click)を観測

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -1115,6 +1115,33 @@ export function DrawingCanvas({
     };
   }, []);
 
+  // Cross-channel input observation. The freeze is confirmed to suspend *touch*
+  // delivery page-wide (canvas + DOM both go dead). Pointer and click events are
+  // a separate WebKit pathway; if they keep firing during the touch-gap a
+  // non-touch channel survives and could anchor a recovery. Pure observation:
+  // passive, capture, no preventDefault — does not touch the canvas pipeline.
+  useEffect(() => {
+    if (!DIAG_ENABLED) return;
+    const onPointerDown = (e: PointerEvent) => {
+      diag.docPointerdown++;
+      if (e.pointerType === 'pen') diag.docPointerPen++;
+    };
+    const onPointerMove = (e: PointerEvent) => {
+      diag.docPointermove++;
+      if (e.pointerType === 'pen') diag.docPointerPen++;
+    };
+    const onClick = () => { diag.docClick++; };
+    const opts = { capture: true, passive: true } as const;
+    document.addEventListener('pointerdown', onPointerDown, opts);
+    document.addEventListener('pointermove', onPointerMove, opts);
+    document.addEventListener('click', onClick, opts);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown, opts);
+      document.removeEventListener('pointermove', onPointerMove, opts);
+      document.removeEventListener('click', onClick, opts);
+    };
+  }, []);
+
   // Mouse fallback handlers
   const isMouseDownRef = useRef(false);
 

--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -127,12 +127,15 @@ export default function TouchDiagnosticsOverlay() {
         const base = secRef.current;
         const dMove = cur.touchmove - base.touchmove;
         const dDoc = cur.docTouchmove - base.docTouchmove;
-        if (dMove > 0 || dDoc > 0 || state?.drawing) {
+        const dPtr = cur.docPointermove - base.docPointermove;
+        const dPen = cur.docPointerPen - base.docPointerPen;
+        if (dMove > 0 || dDoc > 0 || dPtr > 0 || state?.drawing) {
           logEvent('tick', {
             move: dMove, doc: dDoc,
             append: cur.appendOk - base.appendOk,
             redraw: cur.redrawAll - base.redrawAll,
             raf: cur.rafTick - base.rafTick,
+            ptr: dPtr, pen: dPen,
             mode: state?.mode,
           });
         }
@@ -241,6 +244,8 @@ export default function TouchDiagnosticsOverlay() {
         <Box sx={sectionSx}>
           {row('doc move', c.docTouchmove)}
           {row('canvas vs doc move', `${c.touchmove} / ${c.docTouchmove}`, targetGap > 2 ? '#9cf' : undefined)}
+          {row('ptr down/move', `${c.docPointerdown} / ${c.docPointermove}`)}
+          {row('ptr pen / click', `${c.docPointerPen} / ${c.docClick}`)}
         </Box>
         {/* Rejections */}
         <Box sx={sectionSx}>

--- a/src/drawing/touchDiagnostics.ts
+++ b/src/drawing/touchDiagnostics.ts
@@ -101,6 +101,15 @@ export interface DiagCounters {
   docTouchmove: number;
   docTouchend: number;
   docTouchcancel: number;
+  // Cross-channel input arrival — pointer / click events observed at document
+  // level. The confirmed freeze suspends *touch* delivery page-wide; if
+  // pointer/click still fire during the touch-gap, a non-touch channel survives
+  // (a recovery foothold). If none fire, all input is suspended. `docPointerPen`
+  // counts pointer events with pointerType==='pen' (Apple Pencil, incl. hover).
+  docPointerdown: number;
+  docPointermove: number;
+  docPointerPen: number;
+  docClick: number;
   // Session reset.
   resetCount: number;
   lastResetTrigger: ResetTrigger | null;
@@ -117,6 +126,7 @@ function makeCounters(): DiagCounters {
     redrawAll: 0, rafScheduled: 0, lastRedrawAt: 0, heartbeat: 0,
     rafTick: 0, lastRafAt: 0,
     docTouchstart: 0, docTouchmove: 0, docTouchend: 0, docTouchcancel: 0,
+    docPointerdown: 0, docPointermove: 0, docPointerPen: 0, docClick: 0,
     resetCount: 0, lastResetTrigger: null,
   };
 }


### PR DESCRIPTION
## 確定した機序

実機 `?diag=touch` キャプチャ（フォアグラウンド継続・`resetCount 0`・rAF ~60fps 維持）で、ユーザーが実際に描こうとした **約21秒間、canvas にも document にもタッチイベントがゼロ**、かつ **diag の DOM ボタンも反応せず**（`recovery`/`reset` イベント記録ゼロ）であることが確認された。

→ **フリーズ＝WebKit がページ全体へのタッチイベント配信を停止**している状態。仮説A(stylusフィルタ脱落)・B(コンポジッタ未提示)はいずれも反証され、過去の修正 #166/#191 が canvas 内部対策ゆえ原理的に効かなかった理由も説明がついた。

## このPR

タッチとは別系統の **pointer/click イベントがフリーズ中に届くか**を観測する（passive・capture・preventDefault なし、既存タッチ経路に非干渉）:

- カウンタ追加: `docPointerdown` / `docPointermove` / `docPointerPen`(pointerType==='pen'＝Apple Pencil・hover含む) / `docClick`
- 1Hz `tick` スナップショットに `ptr`/`pen` を追加 → フリーズ区間で touch が死んでいても pointer が生きていれば時系列に残る
- オーバーレイに `ptr down/move`・`ptr pen / click` 行を追加

## 次回キャプチャで分かること

フリーズ中に：
- **pointer/click が増える** → タッチ配信だけが止まっている＝非タッチ系統が生存。検出＋検証可能な復旧（pointer フォールバック等）の足がかり。
- **何も増えない** → 全入力がページに配信停止。OS レベル(visibility)以外で復旧不能と確定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add diagnostics to observe pointer and click events during touch freezes, to see if non-touch input still reaches the page. This helps confirm if recovery via pointer fallback is possible or if all input is suspended.

- **New Features**
  - Added document-level counters: `docPointerdown`, `docPointermove`, `docPointerPen` (pointerType `pen`, incl. hover), and `docClick`.
  - Included `ptr` and `pen` deltas in the 1 Hz `tick` snapshot for time-series during freezes.
  - Updated the diagnostics overlay with new rows: `ptr down/move` and `ptr pen / click`.
  - Listeners run in capture mode, are passive, and never call `preventDefault` to avoid interfering with touch handling.

<sup>Written for commit 49c321d04293be8fe6cdcebb2b9cb1b62004cf11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

