### PR TITLE
feat(diag): touchmove 配信遅延を計測（backpressure 裏取り）

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -843,7 +843,18 @@ export function DrawingCanvas({
   const handleTouchMove = useCallback((e: TouchEvent) => {
     e.preventDefault();
 
-    if (DIAG_ENABLED) diag.touchmove++;
+    if (DIAG_ENABLED) {
+      diag.touchmove++;
+      // Delivery latency: how stale is this event by the time our handler runs.
+      // Climbing latency = WebKit's event queue backing up (backpressure), the
+      // suspected cause of the sustained-input freeze. Guard against the legacy
+      // epoch-based timeStamp (would yield a large negative value).
+      const lat = performance.now() - e.timeStamp;
+      if (lat >= 0 && lat < 60000) {
+        diag.moveLatencyLast = lat;
+        if (lat > diag.moveLatencyMax) diag.moveLatencyMax = lat;
+      }
+    }
 
     // Update tracked touches
     for (let i = 0; i < e.changedTouches.length; i++) {

--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -129,6 +129,10 @@ export default function TouchDiagnosticsOverlay() {
         const dDoc = cur.docTouchmove - base.docTouchmove;
         const dPtr = cur.docPointermove - base.docPointermove;
         const dPen = cur.docPointerPen - base.docPointerPen;
+        // Read-and-reset the windowed peak so each tick logs that second's worst
+        // touch-delivery latency — the trend that should climb before the freeze.
+        const latMax = Math.round(cur.moveLatencyMax);
+        diag.moveLatencyMax = 0;
         if (dMove > 0 || dDoc > 0 || dPtr > 0 || state?.drawing) {
           logEvent('tick', {
             move: dMove, doc: dDoc,
@@ -136,6 +140,7 @@ export default function TouchDiagnosticsOverlay() {
             redraw: cur.redrawAll - base.redrawAll,
             raf: cur.rafTick - base.rafTick,
             ptr: dPtr, pen: dPen,
+            latMax,
             mode: state?.mode,
           });
         }
@@ -278,6 +283,11 @@ export default function TouchDiagnosticsOverlay() {
         <Box sx={sectionSx}>
           {row('rafTick', c.rafTick)}
           {row('last rAF (ms)', rafAge, rafAge > RAF_STALL_MS ? '#f66' : undefined)}
+        </Box>
+        {/* Touch delivery latency — climbs if WebKit's event queue backs up */}
+        <Box sx={sectionSx}>
+          {row('move lat last (ms)', Math.round(c.moveLatencyLast),
+            c.moveLatencyLast > 500 ? '#f66' : c.moveLatencyLast > 100 ? '#fc6' : undefined)}
         </Box>
         {/* Reset */}
         <Box sx={sectionSx}>

--- a/src/drawing/touchDiagnostics.ts
+++ b/src/drawing/touchDiagnostics.ts
@@ -110,6 +110,15 @@ export interface DiagCounters {
   docPointermove: number;
   docPointerPen: number;
   docClick: number;
+  // Touch delivery latency (ms) = performance.now() - touchmove.timeStamp.
+  // If WebKit's event queue backs up under sustained 120Hz Pencil input
+  // (the confirmed freeze: sustained drawing → page-wide input suspension,
+  // recovers after a ~2s idle), events arrive increasingly stale and this
+  // climbs in the run-up to the freeze. `moveLatencyMax` is a windowed peak the
+  // overlay reads-and-resets each second so the per-second trend is visible;
+  // `moveLatencyLast` is the most recent sample for the live readout.
+  moveLatencyLast: number;
+  moveLatencyMax: number;
   // Session reset.
   resetCount: number;
   lastResetTrigger: ResetTrigger | null;
@@ -127,6 +136,7 @@ function makeCounters(): DiagCounters {
     rafTick: 0, lastRafAt: 0,
     docTouchstart: 0, docTouchmove: 0, docTouchend: 0, docTouchcancel: 0,
     docPointerdown: 0, docPointermove: 0, docPointerPen: 0, docClick: 0,
+    moveLatencyLast: 0, moveLatencyMax: 0,
     resetCount: 0, lastResetTrigger: null,
   };
 }


### PR DESCRIPTION
## 確定した機序（第2キャプチャ）

`?diag=touch` の pointer 観測（#204）で、フリーズ約24秒間 **touch も pointer も `tick` に一切出ない**＝全入力チャネルが同時停止。ユーザー実機確認「ptr は進まない」「**書き続けるとダメ、2秒休むと復活**」。

> **連続した高頻度 Pencil 入力 → WebKit がページ全体への全入力配信を停止 → ~2秒 idle で再開。メインスレッド/rAF は生存。**

最有力原因（要検証）: canvas の touch リスナーが `{ passive: false }` + 毎イベント `e.preventDefault()`（`touch-action: none` 既設で preventDefault は概ね冗長）。120Hz Pencil 入力をメインスレッドで捌き続けると WebKit のイベントキューが詰まり、iOS が保護的に配信停止する backpressure 挙動と整合。

## このPR（passive 化の前の裏取り）

各 touchmove の**配信遅延** `performance.now() - e.timeStamp` を計測:
- `moveLatencyLast`（直近サンプル、ライブ表示 `move lat last (ms)`、100ms超で黄/500ms超で赤）
- `moveLatencyMax`（毎秒ピーク、オーバーレイが read-and-reset）
- 1Hz `tick` に `latMax` を追加
- レガシー epoch timeStamp は負値ガードで除外

## 次回キャプチャで分かること

- フリーズ直前の `tick` の `latMax` が**増大** → backpressure 確定 → passive 化の修正へ確信を持って進める
- 遅延が**増えずに突然停止** → 別機序（ハードカットオフ）→ 修正方針を見直し

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Measure touchmove delivery latency to validate suspected WebKit backpressure that leads to input freezes. Adds live and per-second latency metrics and per-second logging to spot rising delay before a freeze.

- **New Features**
  - Measure per-event latency as `performance.now() - e.timeStamp`; ignore negative/absurd values.
  - Track `moveLatencyLast` (live) and `moveLatencyMax` (per-second peak, read-and-reset).
  - Log `latMax` in the 1 Hz `tick` for trend analysis.
  - Overlay shows "move lat last (ms)" with color cues (>=100ms yellow, >=500ms red).
  - Diagnostics only; no change to input behavior.

<sup>Written for commit 4182ac3f9a9c8b52b79456a391378d357f7c9a02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

