### PR TITLE
feat(diag): canvas ターゲット喪失の判定を追加し HUD を必要項目だけに

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -1109,8 +1109,15 @@ export function DrawingCanvas({
   // events at all (neither climbs). Pure observation: passive, no preventDefault.
   useEffect(() => {
     if (!DIAG_ENABLED) return;
-    const onStart = () => { diag.docTouchstart++; };
-    const onMove = () => { diag.docTouchmove++; };
+    // Touch events retarget to the element where the touch started, so checking
+    // the canvas against the start element tells us the sequence began on it.
+    const onCanvas = (e: TouchEvent) => {
+      const t = e.target as Node | null;
+      const c = canvasRef.current;
+      return Boolean(c && t && (t === c || c.contains(t)));
+    };
+    const onStart = (e: TouchEvent) => { diag.docTouchstart++; if (onCanvas(e)) diag.docTouchOnCanvas++; };
+    const onMove = (e: TouchEvent) => { diag.docTouchmove++; if (onCanvas(e)) diag.docTouchOnCanvas++; };
     const onEnd = () => { diag.docTouchend++; };
     const onCancel = () => { diag.docTouchcancel++; };
     const opts = { capture: true, passive: true } as const;

--- a/src/components/DrawingCanvasDiagnostics.test.tsx
+++ b/src/components/DrawingCanvasDiagnostics.test.tsx
@@ -105,6 +105,30 @@ describe('DrawingCanvas diagnostics counters', () => {
     expect(rejected[0].detail?.touchType).toBe('direct');
   });
 
+  it('attributes document-observed touches to the canvas, and excludes off-canvas touches', () => {
+    const { canvas } = renderCanvas();
+
+    // A touch sequence on the canvas: the document-level observer sees it AND
+    // attributes it to the canvas target.
+    fireEvent.touchStart(canvas, { touches: [stylus(1, 20, 20)], changedTouches: [stylus(1, 20, 20)] });
+    fireEvent.touchMove(canvas, { touches: [stylus(1, 50, 60)], changedTouches: [stylus(1, 50, 60)] });
+
+    expect(diag.docTouchstart).toBeGreaterThanOrEqual(1);
+    expect(diag.docTouchmove).toBeGreaterThanOrEqual(1);
+    const onCanvasAfterCanvasTouch = diag.docTouchOnCanvas;
+    expect(onCanvasAfterCanvasTouch).toBeGreaterThanOrEqual(2); // start + move
+
+    // A touch elsewhere on the page is still observed by the document listener
+    // but must NOT be attributed to the canvas — this is the signal that tells
+    // "canvas lost its listener" (on-canvas climbs, canvas's own count doesn't)
+    // apart from "user simply touched off-canvas" (on-canvas stays flat).
+    fireEvent.touchStart(document.body, { touches: [direct(9, 5, 5)], changedTouches: [direct(9, 5, 5)] });
+    fireEvent.touchMove(document.body, { touches: [direct(9, 7, 7)], changedTouches: [direct(9, 7, 7)] });
+
+    expect(diag.docTouchstart).toBeGreaterThanOrEqual(2);
+    expect(diag.docTouchOnCanvas).toBe(onCanvasAfterCanvasTouch);
+  });
+
   it('counts resets with their trigger on window blur', () => {
     const { canvas } = renderCanvas();
     fireEvent.touchStart(canvas, { touches: [stylus(1, 20, 20)], changedTouches: [stylus(1, 20, 20)] });

--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -136,6 +136,7 @@ export default function TouchDiagnosticsOverlay() {
         if (dMove > 0 || dDoc > 0 || dPtr > 0 || state?.drawing) {
           logEvent('tick', {
             move: dMove, doc: dDoc,
+            onCanvas: cur.docTouchOnCanvas - base.docTouchOnCanvas,
             append: cur.appendOk - base.appendOk,
             redraw: cur.redrawAll - base.redrawAll,
             raf: cur.rafTick - base.rafTick,
@@ -176,7 +177,6 @@ export default function TouchDiagnosticsOverlay() {
   const s = snap.state;
   const redrawAge = c.lastRedrawAt > 0 ? Math.round(snap.now - c.lastRedrawAt) : -1;
   const rafAge = c.lastRafAt > 0 ? Math.round(snap.now - c.lastRafAt) : -1;
-  const targetGap = c.docTouchmove - c.touchmove;
 
   if (collapsed) {
     return (
@@ -238,61 +238,19 @@ export default function TouchDiagnosticsOverlay() {
         </ToolbarTooltip>
       </Box>
 
-      <Box sx={{ overflow: 'auto', flex: '0 1 auto' }}>
-        {/* Input (canvas) */}
-        <Box sx={sectionSx}>
-          {row('start / move / end', `${c.touchstart} / ${c.touchmove} / ${c.touchend}`)}
-          {row('cancel', c.touchcancel, c.touchcancel > 0 ? '#ff9' : undefined)}
-          {row('type sty/dir/und', `${c.touchTypeStylus} / ${c.touchTypeDirect} / ${c.touchTypeUndefined}`)}
-        </Box>
-        {/* Input (document) */}
-        <Box sx={sectionSx}>
-          {row('doc move', c.docTouchmove)}
-          {row('canvas vs doc move', `${c.touchmove} / ${c.docTouchmove}`, targetGap > 2 ? '#9cf' : undefined)}
-          {row('ptr down/move', `${c.docPointerdown} / ${c.docPointermove}`)}
-          {row('ptr pen / click', `${c.docPointerPen} / ${c.docClick}`)}
-        </Box>
-        {/* Rejections */}
-        <Box sx={sectionSx}>
-          {row('rej frozen', c.rejInputFrozen)}
-          {row('rej pinch', c.rejPinch, c.rejPinch > 0 ? '#fc6' : undefined)}
-          {row('rej stylus s/m', `${c.rejStylusFilterStart} / ${c.rejStylusFilterMove}`,
-            (c.rejStylusFilterStart + c.rejStylusFilterMove) > 0 ? '#fc6' : undefined)}
-          {row('append skip', c.appendSkip)}
-        </Box>
-        {/* State */}
-        <Box sx={sectionSx}>
-          {row('mode / drawing', s ? `${s.mode} / ${s.drawing}` : '?')}
-          {row('hasStylus', String(s?.hasStylus ?? '?'), s?.hasStylus ? '#fc6' : undefined)}
-          {row('activeTouches', s ? `${s.activeTouchCount} [${s.activeTouchIds.join(',')}]` : '?')}
-          {row('pinchActive', String(s?.pinchActive ?? '?'), s?.pinchActive ? '#fc6' : undefined)}
-        </Box>
-        {/* Data */}
-        <Box sx={sectionSx}>
-          {row('start/append/commit', `${c.startStroke} / ${c.appendOk} / ${c.endCommit}`)}
-          {row('cancel', c.cancelStroke)}
-          {row('strokeCount', s?.strokeCount ?? '?')}
-        </Box>
-        {/* Render */}
-        <Box sx={sectionSx}>
-          {row('redrawAll', c.redrawAll)}
-          {row('heartbeat', c.heartbeat)}
-          {row('last redraw (ms)', redrawAge, redrawAge > REDRAW_STALL_MS ? '#f66' : undefined)}
-        </Box>
-        {/* rAF liveness */}
-        <Box sx={sectionSx}>
-          {row('rafTick', c.rafTick)}
-          {row('last rAF (ms)', rafAge, rafAge > RAF_STALL_MS ? '#f66' : undefined)}
-        </Box>
-        {/* Touch delivery latency — climbs if WebKit's event queue backs up */}
-        <Box sx={sectionSx}>
-          {row('move lat last (ms)', Math.round(c.moveLatencyLast),
-            c.moveLatencyLast > 500 ? '#f66' : c.moveLatencyLast > 100 ? '#fc6' : undefined)}
-        </Box>
-        {/* Reset */}
-        <Box sx={sectionSx}>
-          {row('resets', `${c.resetCount} (${c.lastResetTrigger ?? '-'})`)}
-        </Box>
+      {/* Live signals a human watches during a freeze. Everything else lives in
+          the Copy output (serializeLog dumps every counter + the event log), so
+          the on-screen HUD stays small and readable — no scrolling to find the
+          value under investigation. */}
+      <Box sx={{ ...sectionSx, fontSize: '0.82rem', fontWeight: 700 }}>
+        {row('lat last (ms)', Math.round(c.moveLatencyLast),
+          c.moveLatencyLast > 500 ? '#f66' : c.moveLatencyLast > 100 ? '#fc6' : '#9f9')}
+        {row('on-cvs / cvs in', `${c.docTouchOnCanvas} / ${c.touchstart + c.touchmove}`,
+          c.docTouchOnCanvas - (c.touchstart + c.touchmove) > 5 ? '#9cf' : undefined)}
+        {row('mode / draw', s ? `${s.mode} / ${s.drawing}` : '?')}
+        {row('heartbeat', c.heartbeat)}
+        {row('last redraw / rAF (ms)', `${redrawAge} / ${rafAge}`,
+          (redrawAge > REDRAW_STALL_MS || rafAge > RAF_STALL_MS) ? '#f66' : undefined)}
       </Box>
 
       {/* Recovery / live mitigations */}
@@ -319,7 +277,7 @@ export default function TouchDiagnosticsOverlay() {
           </IconButton>
         </ToolbarTooltip>
       </Box>
-      <Box sx={{ mt: 0.5, height: '24dvh', overflow: 'auto', bgcolor: 'rgba(0,0,0,0.4)', borderRadius: 0.5, p: 0.5 }}>
+      <Box sx={{ mt: 0.5, height: '18dvh', overflow: 'auto', bgcolor: 'rgba(0,0,0,0.4)', borderRadius: 0.5, p: 0.5 }}>
         {snap.log.map((e, i) => (
           <Box key={i} sx={{ whiteSpace: 'nowrap', color: e.type === 'watchdog' ? '#f66' : e.type === 'rej' ? '#fc6' : '#bbb' }}>
             {`${e.t.toFixed(0)} ${e.type} ${e.detail ? JSON.stringify(e.detail) : ''}`}

--- a/src/drawing/touchDiagnostics.ts
+++ b/src/drawing/touchDiagnostics.ts
@@ -110,6 +110,12 @@ export interface DiagCounters {
   docPointermove: number;
   docPointerPen: number;
   docClick: number;
+  // Document-observed touches whose target is the canvas element. If this
+  // climbs while the canvas's OWN listener counter (touchmove) stays flat, the
+  // element is still receiving touches but its listener is dead/detached
+  // (target/listener loss) — vs. the user simply touching off-canvas (this
+  // stays flat too). Settles the erase-mode "doc>canvas, finger" signature.
+  docTouchOnCanvas: number;
   // Touch delivery latency (ms) = performance.now() - touchmove.timeStamp.
   // If WebKit's event queue backs up under sustained 120Hz Pencil input
   // (the confirmed freeze: sustained drawing → page-wide input suspension,
@@ -136,6 +142,7 @@ function makeCounters(): DiagCounters {
     rafTick: 0, lastRafAt: 0,
     docTouchstart: 0, docTouchmove: 0, docTouchend: 0, docTouchcancel: 0,
     docPointerdown: 0, docPointermove: 0, docPointerPen: 0, docClick: 0,
+    docTouchOnCanvas: 0,
     moveLatencyLast: 0, moveLatencyMax: 0,
     resetCount: 0, lastResetTrigger: null,
   };


### PR DESCRIPTION
## 第3キャプチャ（erase 中フリーズ）の所見

- **配信遅延 `latMax` は終始 15〜22ms でフラット**（密な連続描画区間も含む）→ **backpressure 仮説は不支持**。passive 化の修正は今の証拠では正当化されない（「まず計測で確定」が効いて誤修正を回避）。
- 一方フリーズ中の tick は `move:0` なのに `doc:33`(指, `pen:0`) → **document には届くが canvas には届かない**別 signature。ただしこの指タッチが canvas 上だったか外だったか今のログでは不明。

## このPR

**1. canvas ターゲット喪失の判定** — `docTouchOnCanvas`: document が観測したタッチのうちターゲットが canvas のものを数える。
- 増えるのに canvas 自身の `touchmove` が増えない → 要素はイベントを受け取る位置にあるのにリスナーが死んでいる＝**ターゲット/リスナー喪失**を確定
- 増えない → canvas 外を触っていただけ（フリーズではない）
- `tick` に `onCanvas` 追加

**2. HUD を人間がライブで見る項目だけに削減** — ご要望「人間が確認すべき項目以外は表示しなくていい（Copy に入っていれば調査できる）」に対応。
- 表示: `lat last` / `on-cvs vs cvs in` / `mode・draw` / `heartbeat` / `last redraw・rAF` のみ
- 詳細カウンタは全て **Copy (`serializeLog`)** に入るので調査に支障なし
- スクロール不要で要点が見える。イベントログ高さ 24→18dvh

## 次回キャプチャ

フリーズしたら `on-cvs / cvs in` を見る → 左(on-canvas)が増えるのに右(canvas in)が増えなければターゲット/リスナー喪失確定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add canvas target-loss detection and slim the diagnostics HUD to focus on freeze signals. Also add a test that verifies `docTouchOnCanvas` increments only for on-canvas touches.

- **New Features**
  - Count `docTouchOnCanvas` by checking document touch targets against the canvas; compare with canvas `touchstart+touchmove` to tell target/listener loss from off-canvas touches.
  - Emit `tick.onCanvas` to correlate freezes in the event stream.
  - HUD now shows: lat last, on-cvs vs cvs in, mode/draw, heartbeat, last redraw/rAF; log pane height 24→18dvh. Full counters remain in Copy via `serializeLog`.

<sup>Written for commit d65373327ea7d0079f63b8f118a87be253724048. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

