### PR TITLE
fix(drawing): canvas の touch リスナーを passive 化（iPad フリーズ A/B 実験）

### DIFF
--- a/src/components/DrawingCanvas.test.tsx
+++ b/src/components/DrawingCanvas.test.tsx
@@ -418,3 +418,39 @@ describe('DrawingCanvas erase mode (unified tap-select / drag-lasso)', () => {
     }
   });
 });
+
+// With passive touch listeners we no longer preventDefault, so iOS emits
+// compatibility ("synthetic") mouse events after a touch. Before any stylus
+// contact hasStylusRef is false, so without a guard those would re-enter the
+// mouse handlers and double up the stroke a finger touch already drew.
+describe('DrawingCanvas synthetic-mouse suppression after touch', () => {
+  function finger(identifier: number, clientX: number, clientY: number): Touch {
+    return { identifier, clientX, clientY, touchType: 'direct' } as Touch & { touchType: string };
+  }
+
+  it('ignores the mouse events that follow a finger touch (no second stroke)', () => {
+    const sm = new StrokeManager();
+    const { canvas } = renderCanvas(sm); // pen mode, no prior stylus
+
+    fireEvent.touchStart(canvas, { touches: [finger(1, 50, 50)], changedTouches: [finger(1, 50, 50)] });
+    fireEvent.touchMove(canvas, { touches: [finger(1, 70, 80)], changedTouches: [finger(1, 70, 80)] });
+    fireEvent.touchEnd(canvas, { touches: [], changedTouches: [finger(1, 70, 80)] });
+    expect(sm.getStrokes()).toHaveLength(1);
+
+    // Synthetic mouse events immediately after the touch must not draw again.
+    fireEvent.mouseDown(canvas, { clientX: 70, clientY: 80 });
+    fireEvent.mouseMove(canvas, { clientX: 90, clientY: 100 });
+    fireEvent.mouseUp(canvas, { clientX: 90, clientY: 100 });
+    expect(sm.getStrokes()).toHaveLength(1);
+  });
+
+  it('still draws with a real mouse when no touch preceded it', () => {
+    const sm = new StrokeManager();
+    const { canvas } = renderCanvas(sm);
+
+    fireEvent.mouseDown(canvas, { clientX: 50, clientY: 50 });
+    fireEvent.mouseMove(canvas, { clientX: 70, clientY: 80 });
+    fireEvent.mouseUp(canvas, { clientX: 70, clientY: 80 });
+    expect(sm.getStrokes()).toHaveLength(1);
+  });
+});

--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -94,6 +94,9 @@ const ERASER_THRESHOLD = 20;
 // world-space threshold would make the lasso fire on tiny hand jitter at high
 // zoom.
 const ERASE_LASSO_THRESHOLD = 8;
+// A mouse event arriving within this window of a touch is a compatibility
+// ("synthetic") mouse event the browser emits after touch — ignore it.
+const SYNTHETIC_MOUSE_GUARD_MS = 700;
 
 export function DrawingCanvas({
   mode,
@@ -124,6 +127,12 @@ export function DrawingCanvas({
   });
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  // Timestamp of the last touch event. With passive touch listeners we no longer
+  // preventDefault, so iOS fires compatibility ("synthetic") mouse events right
+  // after a touch sequence. The mouse handlers ignore any mouse event within
+  // SYNTHETIC_MOUSE_GUARD_MS of a touch so a finger draw (before any stylus, when
+  // hasStylusRef is still false) can't also fire handleMouseDown and double up.
+  const lastTouchAtRef = useRef(0);
   const rendererRef = useRef<CanvasRenderer | null>(null);
   // Lazy-init: useRef's argument runs every render, so a plain default would
   // allocate a throw-away ViewTransform on each render. The non-null cast is
@@ -722,6 +731,8 @@ export function DrawingCanvas({
   // No preventDefault: scroll/zoom are prevented by touch-action: none and
   // selection/callout by CSS, so the browser default is already suppressed.
   const handleTouchStart = useCallback((e: TouchEvent) => {
+    lastTouchAtRef.current = performance.now();
+
     if (DIAG_ENABLED) {
       diag.touchstart++;
       for (let i = 0; i < e.changedTouches.length; i++) {
@@ -836,6 +847,8 @@ export function DrawingCanvas({
   }, [mode, getCanvasPoint, strokeManager, onCurrentStrokeChange, requestRedraw, cancelLasso, beginErasePending, onStrokeStart, syncActiveTouchesFromEvent, clearStalePinchAfterTouchSync]);
 
   const handleTouchMove = useCallback((e: TouchEvent) => {
+    lastTouchAtRef.current = performance.now();
+
     if (DIAG_ENABLED) {
       diag.touchmove++;
       // Delivery latency: how stale is this event by the time our handler runs.
@@ -921,6 +934,8 @@ export function DrawingCanvas({
   }, [mode, getCanvasPoint, requestRedraw, strokeManager, isFlipped, onCurrentStrokeChange, getBaseScale, advanceErasePending]);
 
   const handleTouchEnd = useCallback((e: TouchEvent) => {
+    lastTouchAtRef.current = performance.now();
+
     if (DIAG_ENABLED) {
       if (e.type === 'touchcancel') diag.touchcancel++;
       else diag.touchend++;
@@ -1159,6 +1174,9 @@ export function DrawingCanvas({
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (hasStylusRef.current) return;
+    // Ignore the compatibility mouse event that follows a touch (a real touch
+    // already started the stroke). Real desktop mouse has no preceding touch.
+    if (performance.now() - lastTouchAtRef.current < SYNTHETIC_MOUSE_GUARD_MS) return;
     if (inputFrozenRef.current) return;
     isMouseDownRef.current = true;
 

--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -718,14 +718,10 @@ export function DrawingCanvas({
     }
   }, [strokeManager, getCurrentScale, highlightedStrokeIndex, onDeleteHighlightedStroke, onHighlightStroke, finishLasso]);
 
-  // Touch handlers — registered as native listeners (see effect below) with
-  // { passive: false } so preventDefault works. React 18 attaches synthetic
-  // touch handlers as passive by default, which would silently ignore our
-  // preventDefault calls and emit "Unable to preventDefault inside passive
-  // event listener" warnings.
+  // Touch handlers — registered as native passive listeners (see effect below).
+  // No preventDefault: scroll/zoom are prevented by touch-action: none and
+  // selection/callout by CSS, so the browser default is already suppressed.
   const handleTouchStart = useCallback((e: TouchEvent) => {
-    e.preventDefault();
-
     if (DIAG_ENABLED) {
       diag.touchstart++;
       for (let i = 0; i < e.changedTouches.length; i++) {
@@ -748,9 +744,8 @@ export function DrawingCanvas({
     }
 
     // Gesture-session swap window: reject the new touch entirely (no stroke
-    // start, no pinch arming) so a reflexive post-swap tap is dropped. We
-    // still preventDefault above so the browser doesn't fall back to default
-    // touch behavior (scroll, etc.).
+    // start, no pinch arming) so a reflexive post-swap tap is dropped.
+    // (touch-action: none keeps the browser from scrolling/zooming regardless.)
     if (inputFrozenRef.current) {
       if (DIAG_ENABLED) { diag.rejInputFrozen++; logEvent('rej', { reason: 'inputFrozen' }); }
       return;
@@ -841,8 +836,6 @@ export function DrawingCanvas({
   }, [mode, getCanvasPoint, strokeManager, onCurrentStrokeChange, requestRedraw, cancelLasso, beginErasePending, onStrokeStart, syncActiveTouchesFromEvent, clearStalePinchAfterTouchSync]);
 
   const handleTouchMove = useCallback((e: TouchEvent) => {
-    e.preventDefault();
-
     if (DIAG_ENABLED) {
       diag.touchmove++;
       // Delivery latency: how stale is this event by the time our handler runs.
@@ -928,11 +921,6 @@ export function DrawingCanvas({
   }, [mode, getCanvasPoint, requestRedraw, strokeManager, isFlipped, onCurrentStrokeChange, getBaseScale, advanceErasePending]);
 
   const handleTouchEnd = useCallback((e: TouchEvent) => {
-    // touchend can fire with cancelable=false during scrolling; guard so we
-    // don't trip an "Ignored attempt to cancel a touchend" intervention
-    // warning (the preventDefault would be a no-op anyway).
-    if (e.cancelable) e.preventDefault();
-
     if (DIAG_ENABLED) {
       if (e.type === 'touchcancel') diag.touchcancel++;
       else diag.touchend++;
@@ -1004,9 +992,15 @@ export function DrawingCanvas({
   useEffect(() => { handleTouchEndRef.current = handleTouchEnd; });
 
   // Register touch listeners natively (not via React's synthetic onTouch*
-  // props) so we can pass { passive: false } and actually preventDefault.
-  // Without this, browsers warn "Unable to preventDefault inside passive
-  // event listener" on every move during a stroke.
+  // props) so we control the { passive } flag explicitly.
+  // PASSIVE EXPERIMENT (iPad freeze): the confirmed freeze is a WebKit/iPadOS
+  // page-wide input-delivery suspension under sustained Pencil input. We ruled
+  // out our filter / pinch / backpressure / listener-loss / main-thread stall.
+  // Non-passive listeners make WebKit wait on our handler before continuing;
+  // passive listeners let it dispatch-and-continue and may avoid whatever state
+  // triggers the suspension. scroll/zoom are prevented by touch-action: none
+  // and selection/callout by the canvas CSS above, so dropping preventDefault
+  // (now a no-op under passive anyway) should not regress drawing behavior.
   // Effect deps are intentionally [] so the listeners are attached exactly
   // once per canvas mount; the ref bridge above forwards to the latest
   // handler closure on each event.
@@ -1016,10 +1010,10 @@ export function DrawingCanvas({
     const onStart = (e: Event) => handleTouchStartRef.current(e as TouchEvent);
     const onMove = (e: Event) => handleTouchMoveRef.current(e as TouchEvent);
     const onEnd = (e: Event) => handleTouchEndRef.current(e as TouchEvent);
-    canvas.addEventListener('touchstart', onStart, { passive: false });
-    canvas.addEventListener('touchmove', onMove, { passive: false });
-    canvas.addEventListener('touchend', onEnd, { passive: false });
-    canvas.addEventListener('touchcancel', onEnd, { passive: false });
+    canvas.addEventListener('touchstart', onStart, { passive: true });
+    canvas.addEventListener('touchmove', onMove, { passive: true });
+    canvas.addEventListener('touchend', onEnd, { passive: true });
+    canvas.addEventListener('touchcancel', onEnd, { passive: true });
     return () => {
       canvas.removeEventListener('touchstart', onStart);
       canvas.removeEventListener('touchmove', onMove);
@@ -1260,6 +1254,12 @@ export function DrawingCanvas({
           width: '100%',
           height: '100%',
           touchAction: 'none',
+          // With passive touch listeners we no longer preventDefault, so suppress
+          // text selection / the iOS long-press callout declaratively instead.
+          // (scroll/zoom are already prevented by touch-action: none.)
+          userSelect: 'none',
+          WebkitUserSelect: 'none',
+          WebkitTouchCallout: 'none',
           // iOS Safari workaround: promote the canvas to its own composited
           // layer so updates to its bitmap are always pushed to the screen.
           // Without this hint, after some sequence of events (gesture-session

--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -97,6 +97,9 @@ const ERASE_LASSO_THRESHOLD = 8;
 // A mouse event arriving within this window of a touch is a compatibility
 // ("synthetic") mouse event the browser emits after touch — ignore it.
 const SYNTHETIC_MOUSE_GUARD_MS = 700;
+// A touch gap longer than this ends the current continuous-drawing streak.
+// Matches the ~2s idle that recovers the freeze.
+const DRAW_STREAK_RESET_MS = 2000;
 
 export function DrawingCanvas({
   mode,
@@ -133,6 +136,8 @@ export function DrawingCanvas({
   // SYNTHETIC_MOUSE_GUARD_MS of a touch so a finger draw (before any stylus, when
   // hasStylusRef is still false) can't also fire handleMouseDown and double up.
   const lastTouchAtRef = useRef(0);
+  // Start of the current continuous-drawing streak (for diag.drawStreakMs).
+  const streakStartAtRef = useRef(0);
   const rendererRef = useRef<CanvasRenderer | null>(null);
   // Lazy-init: useRef's argument runs every render, so a plain default would
   // allocate a throw-away ViewTransform on each render. The non-null cast is
@@ -727,11 +732,24 @@ export function DrawingCanvas({
     }
   }, [strokeManager, getCurrentScale, highlightedStrokeIndex, onDeleteHighlightedStroke, onHighlightStroke, finishLasso]);
 
+  // Record touch activity: stamps lastTouchAt (for the synthetic-mouse guard,
+  // always) and advances the continuous-drawing streak (diag only). Must run
+  // before lastTouchAt is overwritten so the gap test sees the previous touch.
+  const noteTouch = useCallback(() => {
+    const now = performance.now();
+    if (DIAG_ENABLED) {
+      if (now - lastTouchAtRef.current > DRAW_STREAK_RESET_MS) streakStartAtRef.current = now;
+      diag.drawStreakMs = now - streakStartAtRef.current;
+      if (diag.drawStreakMs > diag.maxDrawStreakMs) diag.maxDrawStreakMs = diag.drawStreakMs;
+    }
+    lastTouchAtRef.current = now;
+  }, []);
+
   // Touch handlers — registered as native passive listeners (see effect below).
   // No preventDefault: scroll/zoom are prevented by touch-action: none and
   // selection/callout by CSS, so the browser default is already suppressed.
   const handleTouchStart = useCallback((e: TouchEvent) => {
-    lastTouchAtRef.current = performance.now();
+    noteTouch();
 
     if (DIAG_ENABLED) {
       diag.touchstart++;
@@ -844,10 +862,10 @@ export function DrawingCanvas({
       strokeManager.startStroke(point);
       if (DIAG_ENABLED) diag.startStroke++;
     }
-  }, [mode, getCanvasPoint, strokeManager, onCurrentStrokeChange, requestRedraw, cancelLasso, beginErasePending, onStrokeStart, syncActiveTouchesFromEvent, clearStalePinchAfterTouchSync]);
+  }, [mode, getCanvasPoint, strokeManager, onCurrentStrokeChange, requestRedraw, cancelLasso, beginErasePending, onStrokeStart, syncActiveTouchesFromEvent, clearStalePinchAfterTouchSync, noteTouch]);
 
   const handleTouchMove = useCallback((e: TouchEvent) => {
-    lastTouchAtRef.current = performance.now();
+    noteTouch();
 
     if (DIAG_ENABLED) {
       diag.touchmove++;
@@ -931,10 +949,10 @@ export function DrawingCanvas({
     if (DIAG_ENABLED) diag.appendOk++;
     onCurrentStrokeChange?.(strokeManager.getCurrentStroke());
     requestRedraw();
-  }, [mode, getCanvasPoint, requestRedraw, strokeManager, isFlipped, onCurrentStrokeChange, getBaseScale, advanceErasePending]);
+  }, [mode, getCanvasPoint, requestRedraw, strokeManager, isFlipped, onCurrentStrokeChange, getBaseScale, advanceErasePending, noteTouch]);
 
   const handleTouchEnd = useCallback((e: TouchEvent) => {
-    lastTouchAtRef.current = performance.now();
+    noteTouch();
 
     if (DIAG_ENABLED) {
       if (e.type === 'touchcancel') diag.touchcancel++;
@@ -992,7 +1010,7 @@ export function DrawingCanvas({
         endErasePending();
       }
     }
-  }, [mode, notifyStrokeCount, redrawAll, strokeManager, onCurrentStrokeChange, endErasePending, cancelLasso, onStrokeFinalized]);
+  }, [mode, notifyStrokeCount, redrawAll, strokeManager, onCurrentStrokeChange, endErasePending, cancelLasso, onStrokeFinalized, noteTouch]);
 
   // Latest-handler refs so the native listeners below can stay attached for
   // the life of the canvas. The handlers themselves have many transitive

--- a/src/components/DrawingCanvasDiagnostics.test.tsx
+++ b/src/components/DrawingCanvasDiagnostics.test.tsx
@@ -129,6 +129,31 @@ describe('DrawingCanvas diagnostics counters', () => {
     expect(diag.docTouchOnCanvas).toBe(onCanvasAfterCanvasTouch);
   });
 
+  it('tracks the continuous-draw streak and resets it after a long idle', () => {
+    const nowSpy = vi.spyOn(performance, 'now');
+    const { canvas } = renderCanvas();
+
+    // First contact: the gap from init is huge, so the streak starts fresh at 0.
+    nowSpy.mockReturnValue(10000);
+    fireEvent.touchStart(canvas, { touches: [stylus(1, 20, 20)], changedTouches: [stylus(1, 20, 20)] });
+    expect(diag.drawStreakMs).toBe(0);
+
+    // 1s later, still inside the streak window → the streak grows.
+    nowSpy.mockReturnValue(11000);
+    fireEvent.touchMove(canvas, { touches: [stylus(1, 30, 30)], changedTouches: [stylus(1, 30, 30)] });
+    expect(diag.drawStreakMs).toBe(1000);
+
+    nowSpy.mockReturnValue(11200);
+    fireEvent.touchEnd(canvas, { touches: [], changedTouches: [stylus(1, 30, 30)] });
+    expect(diag.maxDrawStreakMs).toBe(1200);
+
+    // A >2s idle then a new contact resets the streak; the max is retained.
+    nowSpy.mockReturnValue(15000);
+    fireEvent.touchStart(canvas, { touches: [stylus(2, 40, 40)], changedTouches: [stylus(2, 40, 40)] });
+    expect(diag.drawStreakMs).toBe(0);
+    expect(diag.maxDrawStreakMs).toBe(1200);
+  });
+
   it('counts resets with their trigger on window blur', () => {
     const { canvas } = renderCanvas();
     fireEvent.touchStart(canvas, { touches: [stylus(1, 20, 20)], changedTouches: [stylus(1, 20, 20)] });

--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -29,6 +29,12 @@ const POLL_MS = 250;
 // Thresholds (ms) after which "no redraw" / "no rAF tick" is treated as stalled.
 const REDRAW_STALL_MS = 500;
 const RAF_STALL_MS = 500;
+// Freeze auto-detection: input silent for longer than this, while a streak of at
+// least FREEZE_MIN_STREAK_MS was active and rAF stayed alive, is flagged as a
+// (suspected) freeze episode. The gap floor is above a normal reposition pause;
+// the streak floor avoids flagging an idle-at-rest as a freeze.
+const FREEZE_GAP_MS = 1500;
+const FREEZE_MIN_STREAK_MS = 2000;
 
 interface Snapshot {
   counters: typeof diag;
@@ -61,6 +67,13 @@ export default function TouchDiagnosticsOverlay() {
   // user recovers (tab switch) before reading the live counters.
   const secRef = useRef<typeof diag>({ ...diag });
   const tickCountRef = useRef(0);
+  // Freeze auto-detection state. (0-init; the poll self-corrects on the first
+  // tick — useRef args must be pure, so no performance.now() / diag reads here.)
+  const lastInputCountRef = useRef(0);
+  const lastInputAtRef = useRef(0);
+  const inFreezeRef = useRef(false);
+  const freezeOnsetAtRef = useRef(0);
+  const freezePreStreakRef = useRef(0);
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -113,6 +126,37 @@ export default function TouchDiagnosticsOverlay() {
       }
       else if (!stuck) {
         stuckRef.current = false;
+      }
+
+      // Freeze auto-detection. Watch total input (start+move); a silent spell
+      // after an active streak with rAF still alive is a (suspected) freeze.
+      const inputCount = cur.touchstart + cur.touchmove;
+      const rafAlive = cur.lastRafAt > 0 && (now - cur.lastRafAt) < RAF_STALL_MS;
+      if (inputCount > lastInputCountRef.current) {
+        if (inFreezeRef.current) {
+          // Input resumed → the episode ends. Log its silent duration + the
+          // streak that preceded it.
+          const durationMs = Math.round(now - freezeOnsetAtRef.current);
+          diag.freezeCount++;
+          diag.lastFreezeMs = durationMs;
+          logEvent('freeze', { durationMs, preStreakMs: Math.round(freezePreStreakRef.current) });
+          persistLog();
+          inFreezeRef.current = false;
+        }
+        lastInputCountRef.current = inputCount;
+        lastInputAtRef.current = now;
+      }
+      else if (!inFreezeRef.current
+        && now - lastInputAtRef.current > FREEZE_GAP_MS
+        && cur.drawStreakMs >= FREEZE_MIN_STREAK_MS
+        && rafAlive) {
+        // drawStreakMs stops updating once input goes silent, so it still holds
+        // the pre-freeze streak here.
+        inFreezeRef.current = true;
+        freezeOnsetAtRef.current = lastInputAtRef.current;
+        freezePreStreakRef.current = cur.drawStreakMs;
+        logEvent('freezeOnset', { preStreakMs: Math.round(cur.drawStreakMs) });
+        persistLog();
       }
 
       // 1Hz activity-gated timeline. Every ~1s, if there was touch activity in
@@ -193,7 +237,7 @@ export default function TouchDiagnosticsOverlay() {
           display: 'flex', alignItems: 'center', gap: 0.5,
         }}
       >
-        <span>{`diag #${c.heartbeat} a${c.appendOk}`}</span>
+        <span style={{ color: c.freezeCount > 0 ? '#f66' : undefined }}>{`diag #${c.heartbeat} frz${c.freezeCount}`}</span>
         <ToolbarTooltip title="Expand diagnostics">
           <IconButton size="small" onClick={() => setCollapsed(false)} sx={{ color: '#0f0', p: 0.25 }}>
             <Maximize2 size={14} />
@@ -243,10 +287,8 @@ export default function TouchDiagnosticsOverlay() {
           the on-screen HUD stays small and readable — no scrolling to find the
           value under investigation. */}
       <Box sx={{ ...sectionSx, fontSize: '0.82rem', fontWeight: 700 }}>
-        {row('lat last (ms)', Math.round(c.moveLatencyLast),
-          c.moveLatencyLast > 500 ? '#f66' : c.moveLatencyLast > 100 ? '#fc6' : '#9f9')}
-        {row('on-cvs / cvs in', `${c.docTouchOnCanvas} / ${c.touchstart + c.touchmove}`,
-          c.docTouchOnCanvas - (c.touchstart + c.touchmove) > 5 ? '#9cf' : undefined)}
+        {row('draw streak (s) / max', `${(c.drawStreakMs / 1000).toFixed(1)} / ${(c.maxDrawStreakMs / 1000).toFixed(1)}`)}
+        {row('freezes / last (ms)', `${c.freezeCount} / ${c.lastFreezeMs}`, c.freezeCount > 0 ? '#f66' : '#9f9')}
         {row('mode / draw', s ? `${s.mode} / ${s.drawing}` : '?')}
         {row('heartbeat', c.heartbeat)}
         {row('last redraw / rAF (ms)', `${redrawAge} / ${rafAge}`,

--- a/src/drawing/touchDiagnostics.ts
+++ b/src/drawing/touchDiagnostics.ts
@@ -116,6 +116,19 @@ export interface DiagCounters {
   // (target/listener loss) — vs. the user simply touching off-canvas (this
   // stays flat too). Settles the erase-mode "doc>canvas, finger" signature.
   docTouchOnCanvas: number;
+  // Continuous-drawing streak (ms): how long the user has been drawing without
+  // a gap ≥ DRAW_STREAK_RESET_MS. Resets on a long idle. The freeze is triggered
+  // by sustained input, so this is the dose that builds up to it; the overlay
+  // shows it live so a controlled repro ("draw continuously until it freezes")
+  // is quantifiable, and `maxDrawStreakMs` is the A/B yardstick.
+  drawStreakMs: number;
+  maxDrawStreakMs: number;
+  // Auto-detected freeze episodes (heuristic): input went silent for a spell
+  // while a streak was active and rAF stayed alive, then resumed. `lastFreezeMs`
+  // is the most recent episode's silent duration. Lets us count freezes per
+  // session objectively instead of eyeballing gaps in the log.
+  freezeCount: number;
+  lastFreezeMs: number;
   // Touch delivery latency (ms) = performance.now() - touchmove.timeStamp.
   // If WebKit's event queue backs up under sustained 120Hz Pencil input
   // (the confirmed freeze: sustained drawing → page-wide input suspension,
@@ -143,6 +156,8 @@ function makeCounters(): DiagCounters {
     docTouchstart: 0, docTouchmove: 0, docTouchend: 0, docTouchcancel: 0,
     docPointerdown: 0, docPointermove: 0, docPointerPen: 0, docClick: 0,
     docTouchOnCanvas: 0,
+    drawStreakMs: 0, maxDrawStreakMs: 0,
+    freezeCount: 0, lastFreezeMs: 0,
     moveLatencyLast: 0, moveLatencyMax: 0,
     resetCount: 0, lastResetTrigger: null,
   };


### PR DESCRIPTION
## 背景：確定した機序

`?diag=touch` ハーネスの4回の実機キャプチャで、iPad Pencil「描画中に入力が無視される」フリーズの機序を確定した：

> **連続/高頻度の Pencil 入力が続くと、WebKit/iPadOS がページ全体への全入力（touch+pointer）配信を停止する。~2秒の idle（または visibility 変化）で再開。rAF/メインスレッドは生存。**

自分たちのコードに起因する原因はすべて計測で反証済み：
- ❌ stylus フィルタ/pinch 誤認（カウンタ健全）
- ❌ backpressure（配信遅延 9〜23ms フラット、増大なし）
- ❌ canvas リスナー/ターゲット喪失（`on-canvas` も canvas 自身も両方ゼロ）
- ❌ メインスレッド/rAF 停止（raf ~60 継続）

## この PR（A/B 実験）

非 passive リスナーは WebKit がハンドラ完了を待ってから次に進む構造。**passive にすると dispatch-and-continue** になり、停止状態を誘発する内部状態を回避できる可能性がある。これを実機 A/B で検証する。

- canvas の `touchstart/move/end/cancel` を `{ passive: true }` に変更
- `preventDefault` を削除（passive では no-op）。代替として:
  - scroll/zoom → `touch-action: none`（既設）
  - 選択/コールアウト → canvas に `user-select: none` / `-webkit-touch-callout: none` を追加
- `wheel`（trackpad zoom）は preventDefault が必要なので**非 passive のまま**
- 診断ハーネス（`?diag=touch`）は温存

## 検証

iPad で連続/高頻度に描画・消去して、フリーズが**再発しなくなるか**を確認する。再発した場合は `?diag=touch` で再度キャプチャし、この仮説を反証して revert する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make canvas touch listeners passive to mitigate the iPad Pencil freeze by avoiding WebKit’s handler-wait path. Add draw-streak tracking and automatic freeze detection to measure the A/B test while keeping drawing behavior unchanged and preventing post-touch double strokes.

- **Bug Fixes**
  - Make canvas `touchstart/move/end/cancel` passive and remove `preventDefault`; suppress defaults via CSS (`touch-action: none`, `user-select: none`, `-webkit-touch-callout: none`); keep `wheel` non-passive; `?diag=touch` unchanged.
  - Ignore mouse events within 700ms of a touch to block iOS synthetic mouse double-draw; desktop mouse unaffected. Tests added.

- **New Features**
  - Diagnostics: track continuous draw streak (resets after 2s idle) and auto-detect freeze episodes (input silent >1500ms after a ≥2000ms streak with rAF alive). Show streak/freeze in the HUD, log episodes, and add streak tests.

<sup>Written for commit 5c22cd7fd7e476e2d0a9f38ea01f4eb33b46ce65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

