### PR TITLE
fix(drawing): touch リスナーを非passiveに戻す（#207 passive 実験を revert）

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -745,10 +745,15 @@ export function DrawingCanvas({
     lastTouchAtRef.current = now;
   }, []);
 
-  // Touch handlers — registered as native passive listeners (see effect below).
-  // No preventDefault: scroll/zoom are prevented by touch-action: none and
-  // selection/callout by CSS, so the browser default is already suppressed.
+  // Touch handlers — registered as native NON-passive listeners so we can
+  // preventDefault. Reverted from a passive experiment (#207): passive dropped
+  // preventDefault, which let iOS's gesture recognizer steal the first ~0.2s of
+  // a direction-changing stroke (gesture disambiguation), making quick strokes
+  // chip out — badly when writing (e.g. 正). preventDefault claims each touch
+  // immediately and stops that. (It did not fix the separate sustained-input
+  // freeze either; see .claude memory / touchDiagnostics.)
   const handleTouchStart = useCallback((e: TouchEvent) => {
+    e.preventDefault();
     noteTouch();
 
     if (DIAG_ENABLED) {
@@ -865,6 +870,7 @@ export function DrawingCanvas({
   }, [mode, getCanvasPoint, strokeManager, onCurrentStrokeChange, requestRedraw, cancelLasso, beginErasePending, onStrokeStart, syncActiveTouchesFromEvent, clearStalePinchAfterTouchSync, noteTouch]);
 
   const handleTouchMove = useCallback((e: TouchEvent) => {
+    e.preventDefault();
     noteTouch();
 
     if (DIAG_ENABLED) {
@@ -952,6 +958,9 @@ export function DrawingCanvas({
   }, [mode, getCanvasPoint, requestRedraw, strokeManager, isFlipped, onCurrentStrokeChange, getBaseScale, advanceErasePending, noteTouch]);
 
   const handleTouchEnd = useCallback((e: TouchEvent) => {
+    // touchend can fire with cancelable=false during scrolling; guard so we
+    // don't trip an "Ignored attempt to cancel a touchend" intervention warning.
+    if (e.cancelable) e.preventDefault();
     noteTouch();
 
     if (DIAG_ENABLED) {
@@ -1025,15 +1034,12 @@ export function DrawingCanvas({
   useEffect(() => { handleTouchEndRef.current = handleTouchEnd; });
 
   // Register touch listeners natively (not via React's synthetic onTouch*
-  // props) so we control the { passive } flag explicitly.
-  // PASSIVE EXPERIMENT (iPad freeze): the confirmed freeze is a WebKit/iPadOS
-  // page-wide input-delivery suspension under sustained Pencil input. We ruled
-  // out our filter / pinch / backpressure / listener-loss / main-thread stall.
-  // Non-passive listeners make WebKit wait on our handler before continuing;
-  // passive listeners let it dispatch-and-continue and may avoid whatever state
-  // triggers the suspension. scroll/zoom are prevented by touch-action: none
-  // and selection/callout by the canvas CSS above, so dropping preventDefault
-  // (now a no-op under passive anyway) should not regress drawing behavior.
+  // props) so we can pass { passive: false } and actually preventDefault.
+  // React attaches synthetic touch handlers as passive, which would ignore our
+  // preventDefault and emit "Unable to preventDefault inside passive event
+  // listener" warnings. (A passive experiment for the freeze — #207 — was
+  // reverted: it dropped the per-stroke gesture-disambiguation; see the
+  // handleTouchStart comment.)
   // Effect deps are intentionally [] so the listeners are attached exactly
   // once per canvas mount; the ref bridge above forwards to the latest
   // handler closure on each event.
@@ -1043,10 +1049,10 @@ export function DrawingCanvas({
     const onStart = (e: Event) => handleTouchStartRef.current(e as TouchEvent);
     const onMove = (e: Event) => handleTouchMoveRef.current(e as TouchEvent);
     const onEnd = (e: Event) => handleTouchEndRef.current(e as TouchEvent);
-    canvas.addEventListener('touchstart', onStart, { passive: true });
-    canvas.addEventListener('touchmove', onMove, { passive: true });
-    canvas.addEventListener('touchend', onEnd, { passive: true });
-    canvas.addEventListener('touchcancel', onEnd, { passive: true });
+    canvas.addEventListener('touchstart', onStart, { passive: false });
+    canvas.addEventListener('touchmove', onMove, { passive: false });
+    canvas.addEventListener('touchend', onEnd, { passive: false });
+    canvas.addEventListener('touchcancel', onEnd, { passive: false });
     return () => {
       canvas.removeEventListener('touchstart', onStart);
       canvas.removeEventListener('touchmove', onMove);


### PR DESCRIPTION
## なぜ revert するか

passive 化（#207）は iPad フリーズを**解消せず**、かつ**実使用で新たな回帰**を生んだ。

### 実機の症状
- 向きが大きく変わるストローク／素早い書き取り（正の字）で、**5本中数本が ~0.2秒単位で丸ごと欠ける**。
- 同じ向きの線を引き続ける分には**ほぼ欠けない**。

### 原因
`preventDefault` を出さない passive のせいで、**方向転換ストロークの冒頭で iOS のジェスチャ判定（disambiguation）が ~0.2秒 touch を奪い**、短い画が丸ごと消える。`touch-action: none` でも、preventDefault が無いとこの取りこぼしが起きる。

### A/B が誤判定だった理由
60秒連続スクリブル×3 が通ったのは、トリガ（**短ストロークの連打＝書き取りの動き**、既知バグ 664108）を踏んでいなかったため。連続接触はトリガにならない。

## 変更
- canvas の `touchstart/move/end/cancel` を `{ passive: false }` に戻す
- `handleTouchStart/Move/End` の `preventDefault` を復活（touchend は `e.cancelable` ガード）
- document 観測リスナーは観測専用なので passive のまま
- **streak/freeze 自動検出・遅延計測・合成マウスガード・診断ハーネスは温存**

## 残課題
元の「連続入力でのページ全体フリーズ（~21秒で停止、タブ切替で復帰）」は**未解決のまま**（別問題・低頻度）。正しい repro は書き取りパターン（短ストローク連打）。次アプローチは要再検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the passive touch listener experiment (#207) on the drawing canvas and restores non-passive handlers with preventDefault. This stops iOS from stealing initial touch events on direction changes, fixing missing short strokes when writing.

- **Bug Fixes**
  - Use native canvas listeners with `{ passive: false }` for `touchstart/move/end/cancel`.
  - Re-enable `preventDefault()` in `touchstart/move/end` (guard `touchend` with `e.cancelable`).
  - Keep document observers passive; diagnostics unchanged. The rare sustained-input freeze remains.

<sup>Written for commit f3ede7f6d726e085b9a4e8fee29fdaeb787463a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

