### PR TITLE
docs: sync AGENTS guidance with Claude updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Prefer `npm run test` over watch mode in agent / CI-style runs.
 - Vite + React + TypeScript strict mode
 - Material UI
 - Vitest + React Testing Library
-- Dexie / IndexedDB schema v13 for persistence
+- Dexie / IndexedDB schema v14 for persistence
 - GitHub Pages via GitHub Actions
 
 ## Code Map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for Codex when working in this repository.
 
 ## Project
 
-Drawing Practice is an iPad-focused line-drawing practice app. The screen is split between a reference viewer and a drawing canvas, with shared grid / guide alignment.
+Drawing Practice is an iPad + Apple Pencil focused line-drawing practice app. The screen is split between a reference viewer and a drawing canvas, with shared grid / guide alignment. References include Sketchfab models, images, YouTube videos, Pexels photos, and bundled trace templates; trace templates score strokes against target shapes and show red deviation feedback.
 
 Live app: https://koizuka.github.io/drawing-practice/
 
@@ -19,16 +19,19 @@ npm run test
 npm run test:watch
 ```
 
+Prefer `npm run test` over watch mode in agent / CI-style runs.
+
 ## Stack
 
-- Vite + React + TypeScript
+- Vite + React + TypeScript strict mode
 - Material UI
 - Vitest + React Testing Library
-- Dexie / IndexedDB for persistence
+- Dexie / IndexedDB schema v13 for persistence
+- GitHub Pages via GitHub Actions
 
 ## Code Map
 
-- `src/components/SplitLayout.tsx`: top-level state owner for reference, timer, autosave, and undoable reference changes
+- `src/components/SplitLayout.tsx`: top-level state owner for reference, timer, autosave, undoable reference changes, panel collapse, shared `StrokeManager`, and restore gating
 - `src/components/ReferencePanel.tsx`: reference source selection and reference-side toolbar
 - `src/components/DrawingPanel.tsx`: drawing-side toolbar, timer, undo/redo, save, gallery
 - `src/components/DrawingCanvas.tsx`: drawing input, rendering, zoom/pan, grid/guide rendering
@@ -36,9 +39,12 @@ npm run test:watch
 - `src/components/ImageViewer.tsx`: image reference viewer with shared overlays
 - `src/components/YouTubeViewer.tsx`: YouTube iframe viewer with overlay-based interaction model
 - `src/components/PexelsSearcher.tsx`: Pexels search UI and selection flow
+- `src/components/TraceTemplateViewer.tsx`, `src/components/BundledTemplatePicker.tsx`: trace template viewing, browsing, and scoring flows
 - `src/components/Gallery.tsx`: saved drawing gallery, export, reload reference, storage summary
 - `src/drawing/StrokeManager.ts`: shared undo/redo history for strokes and reference changes
 - `src/guides/`: grid / guide shared state and rendering
+- `src/trace/TraceScoringContext.tsx`: shared trace-template scoring state
+- `src/trace/`, `src/templates/`: trace template definitions, scoring, and bundled assets
 - `src/storage/`: IndexedDB schema, draft persistence, URL history, export, storage accounting
 - `src/hooks/useTimer.ts`: drawing timer lifecycle
 - `src/hooks/useAutosave.ts`: debounced session draft persistence
@@ -47,11 +53,19 @@ npm run test:watch
 ## Architectural Rules
 
 - Keep the reference panel and drawing panel in the same logical coordinate space. Grid, guides, overlay strokes, and fit sizing must stay aligned across both panels.
-- Reference mutations should flow through `SplitLayout` so they are captured in undo history. Avoid introducing direct local mutations that bypass `changeReference(...)`.
+- Shared camera state is a `ViewTransform` model: `viewCenter` in world coordinates plus `zoom`, projected into each panel with its own `baseScale`. Pan / zoom should survive UI navigation and reset only on actual content load via the fitting viewer.
+- Split layout switches between side-by-side and stacked panels by orientation. The reference panel can be collapsed for free drawing from the drawing toolbar, and that collapsed state is autosaved.
+- `drawingFitSize` must be derived from `fitLeader`, not raw `referenceSize`; source pickers and search screens may still have stale reference dimensions.
+- World origin is the grid center. References are rendered centered at `(0, 0)`, and stored strokes / guides use `coordVersion` migration for legacy data.
+- Reference mutations should flow through `SplitLayout.changeReference(mutate, opts?)` so they are captured in undo history, pause the timer, and bump history sync state. Use `{ recordUndo: false }` only for intentionally non-undoable flows such as rapid gesture-driven photo advancement. Image-load errors use the separate non-undoable reset path.
 - Undo/redo history covers both strokes and reference changes. When changing reference behavior, verify undo/redo semantics.
 - Autosave persists the current session state, but reference undo history is intentionally session-only and not restored after reload.
+- `SplitLayout` intentionally gates panel rendering until draft restore is complete or no session lock exists. Do not replace this with hidden-but-mounted panels; first-paint toolbar transitions are user-visible.
+- Autosave uses a 2s debounce for freehand stroke commits, immediate flush for reference changes and discrete UI actions, and a short camera tail-debounce. Camera home / unfit adjustment paths intentionally suppress autosave.
 - Timer behavior is user-visible product logic. Reference changes, save, gallery open, backgrounding, and fully undoing strokes all affect timer state.
 - IndexedDB usage matters. Prefer bounded history, quantized persisted stroke data, and reuse of existing storage helpers.
+- Canvas work must account for `window.devicePixelRatio`, and viewport sizing should use `100dvh` rather than `100vh` for iPad Safari.
+- The touch diagnostics harness behind `?diag=touch` is opt-in and dormant otherwise. Keep diagnostic code behind `DIAG_ENABLED` guards; if removing it, delete the recorder / overlay and all guarded call sites together.
 
 ## Detailed Rule Documents
 
@@ -63,6 +77,7 @@ For path-specific behavior and product rules, also check `.claude/rules/`:
 - `storage.md`: `src/storage/**` and storage accounting / history behavior
 - `gallery.md`: `Gallery.tsx`, export, and restored-reference flows
 - `ui-design-principles.md`: component-level UI structure and interaction patterns
+- `trace-template.md`: `src/trace/**`, `src/templates/**`, `TraceTemplateViewer.tsx`, `BundledTemplatePicker.tsx`
 
 Read the relevant rule document before changing those areas. Keep `AGENTS.md` as the stable high-level map, and treat the rule documents as the detailed source of truth for scoped behavior.
 
@@ -71,7 +86,9 @@ Read the relevant rule document before changing those areas. Keep `AGENTS.md` as
 - URL input auto-detects YouTube, Pexels, and Sketchfab URLs and routes them into dedicated flows rather than treating everything as a plain image URL.
 - Sketchfab "Fix This Angle" captures a screenshot that becomes the fixed reference and also the persisted thumbnail for gallery / history restore.
 - YouTube supports playback interaction through an overlay mode switch; still-frame capture is intentionally unsupported.
+- Pexels API keys are user-supplied and stored in `localStorage['pexelsApiKey']`; never bundle a key.
 - Local images and Sketchfab screenshots are stored in URL history so references can be restored later.
+- Trace template replacement / undo semantics are path-specific; read `trace-template.md` before changing template state, scoring, or bundled template behavior.
 
 ## Storage Notes
 
@@ -79,7 +96,7 @@ Read the relevant rule document before changing those areas. Keep `AGENTS.md` as
 - `drawings` stores quantized strokes for size control. Do not accidentally apply that quantization to in-memory editing behavior.
 - `session` is the autosave draft.
 - `urlHistory` is split-capped so image-heavy usage does not evict all non-image history.
-- Database name is scoped by `BASE_URL` so preview deployments do not share data with production.
+- Database name is scoped by `BASE_URL` so preview deployments do not share data with production. Main uses `DrawingPracticeDB`; previews use `DrawingPracticeDB_{basePath}` and have cleanup behavior for stale preview DBs.
 
 ## Working Style For Codex
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ npm run test:watch # Run tests in watch mode (prefer `npm run test` in CI/agent 
 
 ## Tech Stack
 
-Vite + React + TypeScript (strict mode), Material-UI, Vitest + React Testing Library, Dexie.js (IndexedDB schema v13), GitHub Pages via GitHub Actions.
+Vite + React + TypeScript (strict mode), Material-UI, Vitest + React Testing Library, Dexie.js (IndexedDB schema v14), GitHub Pages via GitHub Actions.
 
 ## High-level Architecture
 


### PR DESCRIPTION
## Summary
- Reflect recent CLAUDE.md guidance in AGENTS.md for Codex workflows
- Add trace template, camera/fit sizing, restore gate, autosave, diagnostics, and storage notes

## Validation
- npm run lint
- npm run build

Targeted tests were not run because this is a documentation-only update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `AGENTS.md` with the latest `CLAUDE.md` and updates Dexie/IndexedDB guidance to schema v14. Adds trace‑template scoring rules, shared camera/fit sizing, panel collapse + restore gating, autosave/timer updates, diagnostics guards, DB scoping notes, updated code‑map entries (trace components), and a note to prefer `npm run test`.

<sup>Written for commit 8d73cf1c2e15c5731f1372812093ea5796de2a22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

