### PR TITLE
fix(diag): ログ圧縮で長い時間軸を確保し HUD を簡素化/幅安定化

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -301,19 +301,16 @@ export function DrawingCanvas({
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
     // Diagnostic heartbeat (screen space, DPR-only transform): a per-frame
-    // counter + moving dot painted ON the canvas. If the overlay's redrawAll /
-    // rafTick counters keep climbing but this marker is visually frozen while
-    // drawing, the compositor isn't presenting new canvas content (render-side
-    // stall) — the key discriminator vs. an input-side drop.
+    // moving dot painted ON the canvas. If the overlay's redrawAll / rafTick
+    // counters keep climbing but this dot is visually frozen while drawing, the
+    // compositor isn't presenting new canvas content (render-side stall) — the
+    // key discriminator vs. an input-side drop. The monotonic `#N` text was
+    // dropped (visually noisy, ever-growing); a moving dot is sufficient proof.
     if (DIAG_ENABLED) {
       ctx.save();
       ctx.fillStyle = 'rgba(220,0,0,0.85)';
-      ctx.fillRect(4, 4, 58, 18);
-      ctx.fillStyle = '#fff';
-      ctx.font = '12px monospace';
-      ctx.fillText(`#${diag.heartbeat}`, 7, 17);
       ctx.beginPath();
-      ctx.arc(72 + (diag.heartbeat % 20) * 3, 13, 3, 0, 2 * Math.PI);
+      ctx.arc(10 + (diag.heartbeat % 20) * 3, 12, 3, 0, 2 * Math.PI);
       ctx.fill();
       ctx.restore();
     }
@@ -760,17 +757,25 @@ export function DrawingCanvas({
         else if (tt === undefined) diag.touchTypeUndefined++;
         else diag.touchTypeDirect++;
       }
+      // Per-stroke start logging is suppressed for the normal single-stylus
+      // case — it floods the 200-entry ring during sustained short-stroke
+      // writing and evicts the freeze trail. The 1Hz `tick` carries the
+      // per-second start count instead. Only log anomalous starts worth
+      // inspecting: a non-stylus touch (the Pencil-misclassified-as-direct
+      // suspect) or a multi-touch start.
       const t0 = e.changedTouches[0] as Touch & { touchType?: string };
-      logEvent('start', {
-        mode,
-        changed: e.changedTouches.length,
-        touches: e.touches.length,
-        touchType: t0?.touchType,
-        // Radius lets us check whether a misclassified-as-'direct' Pencil touch
-        // is distinguishable from a finger (Pencil ~1-2px, finger ~20-40px).
-        rX: t0 ? Math.round((t0.radiusX ?? 0) * 10) / 10 : undefined,
-        force: t0 ? Math.round((t0.force ?? 0) * 100) / 100 : undefined,
-      });
+      if (t0?.touchType !== 'stylus' || e.touches.length > 1) {
+        logEvent('start', {
+          mode,
+          changed: e.changedTouches.length,
+          touches: e.touches.length,
+          touchType: t0?.touchType,
+          // Radius lets us check whether a misclassified-as-'direct' Pencil touch
+          // is distinguishable from a finger (Pencil ~1-2px, finger ~20-40px).
+          rX: t0 ? Math.round((t0.radiusX ?? 0) * 10) / 10 : undefined,
+          force: t0 ? Math.round((t0.force ?? 0) * 100) / 100 : undefined,
+        });
+      }
     }
 
     // Gesture-session swap window: reject the new touch entirely (no stroke
@@ -962,7 +967,14 @@ export function DrawingCanvas({
     if (DIAG_ENABLED) {
       if (e.type === 'touchcancel') diag.touchcancel++;
       else diag.touchend++;
-      logEvent(e.type, { changed: e.changedTouches.length, remaining: e.touches.length });
+      // Per-stroke end logging is suppressed for the normal single-touch
+      // touchend (counters above still tally it; the 1Hz `tick` carries the
+      // rate). Only log the investigation-relevant cases: a touchcancel, or a
+      // multi-touch end with touches still down.
+      if (e.type === 'touchcancel' || e.touches.length > 0) {
+        logEvent(e.type, { changed: e.changedTouches.length, remaining: e.touches.length });
+      }
+      // persistLog regardless so the ring survives the reload the bug triggers.
       persistLog();
     }
 

--- a/src/components/DrawingCanvasDiagnostics.test.tsx
+++ b/src/components/DrawingCanvasDiagnostics.test.tsx
@@ -83,6 +83,32 @@ describe('DrawingCanvas diagnostics counters', () => {
     expect(diag.redrawAll).toBeGreaterThan(0);
   });
 
+  it('suppresses per-stroke start/end log entries for a normal single-stylus stroke while still counting them', () => {
+    const { canvas } = renderCanvas();
+
+    fireEvent.touchStart(canvas, { touches: [stylus(1, 20, 20)], changedTouches: [stylus(1, 20, 20)] });
+    fireEvent.touchMove(canvas, { touches: [stylus(1, 50, 60)], changedTouches: [stylus(1, 50, 60)] });
+    fireEvent.touchEnd(canvas, { touches: [], changedTouches: [stylus(1, 50, 60)] });
+
+    // Counters still tally the stroke...
+    expect(diag.touchstart).toBe(1);
+    expect(diag.touchend).toBe(1);
+    // ...but the ring buffer must NOT hold a per-stroke start/touchend entry —
+    // that flood is what evicts the freeze trail during sustained writing.
+    expect(getLog().filter(e => e.type === 'start')).toHaveLength(0);
+    expect(getLog().filter(e => e.type === 'touchend')).toHaveLength(0);
+  });
+
+  it('still logs a start entry for a non-stylus (misclassified-Pencil suspect) touch', () => {
+    const { canvas } = renderCanvas();
+
+    fireEvent.touchStart(canvas, { touches: [direct(1, 20, 20)], changedTouches: [direct(1, 20, 20)] });
+
+    const starts = getLog().filter(e => e.type === 'start');
+    expect(starts.length).toBeGreaterThanOrEqual(1);
+    expect(starts[0].detail?.touchType).toBe('direct');
+  });
+
   it('records the Hypothesis-A drop: after a stylus touch, a non-stylus move is rejected by the stylus filter', () => {
     const { canvas, strokeManager } = renderCanvas();
 

--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -57,6 +57,10 @@ export default function TouchDiagnosticsOverlay() {
   const [snap, setSnap] = useState<Snapshot>(() => takeSnapshot());
   const [collapsed, setCollapsed] = useState(false);
   const [copied, setCopied] = useState(false);
+  // Live freeze state, mirrored from the detector refs each poll so the HUD can
+  // show "FROZEN {age}s" *during* the episode (the count only ticks up after
+  // recovery, which is too late to watch).
+  const [freezeLive, setFreezeLive] = useState<{ on: boolean; sinceMs: number }>({ on: false, sinceMs: 0 });
 
   // Previous tick's counters, for the watchdog's delta detection.
   const prevRef = useRef<typeof diag>({ ...diag });
@@ -179,6 +183,9 @@ export default function TouchDiagnosticsOverlay() {
         diag.moveLatencyMax = 0;
         if (dMove > 0 || dDoc > 0 || dPtr > 0 || state?.drawing) {
           logEvent('tick', {
+            // Per-second stroke-start count: per-stroke `start` logging is now
+            // suppressed in DrawingCanvas, so the tick carries the rate instead.
+            start: cur.touchstart - base.touchstart,
             move: dMove, doc: dDoc,
             onCanvas: cur.docTouchOnCanvas - base.docTouchOnCanvas,
             append: cur.appendOk - base.appendOk,
@@ -191,6 +198,10 @@ export default function TouchDiagnosticsOverlay() {
         }
         secRef.current = { ...cur };
       }
+
+      setFreezeLive(inFreezeRef.current
+        ? { on: true, sinceMs: now - freezeOnsetAtRef.current }
+        : { on: false, sinceMs: 0 });
 
       prevRef.current = { ...cur };
       setSnap(takeSnapshot());
@@ -234,10 +245,20 @@ export default function TouchDiagnosticsOverlay() {
           position: 'absolute', top: 84, right: 8, zIndex: 1100,
           bgcolor: 'rgba(0,0,0,0.75)', color: '#0f0', borderRadius: 1,
           px: 1, py: 0.25, fontFamily: 'monospace', fontSize: '0.7rem',
+          fontVariantNumeric: 'tabular-nums',
           display: 'flex', alignItems: 'center', gap: 0.5,
         }}
       >
-        <span style={{ color: c.freezeCount > 0 ? '#f66' : undefined }}>{`diag #${c.heartbeat} frz${c.freezeCount}`}</span>
+        {/* State dot: frozen=red, drawing=green, idle=grey. The monotonic
+            heartbeat number was dropped — its ever-growing digits made the
+            badge width oscillate. */}
+        <span
+          style={{
+            display: 'inline-block', width: 8, height: 8, borderRadius: '50%',
+            backgroundColor: freezeLive.on ? '#f66' : s?.drawing ? '#6f6' : '#666',
+          }}
+        />
+        <span style={{ minWidth: 44, color: c.freezeCount > 0 ? '#f66' : undefined }}>{`frz${c.freezeCount}`}</span>
         <ToolbarTooltip title="Expand diagnostics">
           <IconButton size="small" onClick={() => setCollapsed(false)} sx={{ color: '#0f0', p: 0.25 }}>
             <Maximize2 size={14} />
@@ -268,6 +289,7 @@ export default function TouchDiagnosticsOverlay() {
         display: 'flex', flexDirection: 'column',
         bgcolor: 'rgba(0,0,0,0.82)', color: '#eee', borderRadius: 1,
         fontFamily: 'monospace', fontSize: '0.72rem', lineHeight: 1.45,
+        fontVariantNumeric: 'tabular-nums',
         p: 1, boxShadow: 3,
       }}
     >
@@ -287,10 +309,10 @@ export default function TouchDiagnosticsOverlay() {
           the on-screen HUD stays small and readable — no scrolling to find the
           value under investigation. */}
       <Box sx={{ ...sectionSx, fontSize: '0.82rem', fontWeight: 700 }}>
+        {freezeLive.on && row('▲ FROZEN (s)', (freezeLive.sinceMs / 1000).toFixed(1), '#f66')}
         {row('draw streak (s) / max', `${(c.drawStreakMs / 1000).toFixed(1)} / ${(c.maxDrawStreakMs / 1000).toFixed(1)}`)}
         {row('freezes / last (ms)', `${c.freezeCount} / ${c.lastFreezeMs}`, c.freezeCount > 0 ? '#f66' : '#9f9')}
         {row('mode / draw', s ? `${s.mode} / ${s.drawing}` : '?')}
-        {row('heartbeat', c.heartbeat)}
         {row('last redraw / rAF (ms)', `${redrawAge} / ${rafAge}`,
           (redrawAge > REDRAW_STALL_MS || rafAge > RAF_STALL_MS) ? '#f66' : undefined)}
       </Box>

--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -268,10 +268,14 @@ export default function TouchDiagnosticsOverlay() {
     );
   }
 
+  // Each row is forced to a single line: when a value's digit count grew, the
+  // label+value used to wrap inside the fixed-width panel, changing the row
+  // height and making the rows below jump. The label truncates (ellipsis) and
+  // the value never wraps, so row height is constant regardless of magnitude.
   const row = (label: string, value: ReactNode, color?: string) => (
-    <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1, color: color ?? 'inherit' }}>
-      <span>{label}</span>
-      <span>{value}</span>
+    <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1, color: color ?? 'inherit', whiteSpace: 'nowrap' }}>
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{label}</span>
+      <span style={{ flexShrink: 0 }}>{value}</span>
     </Box>
   );
 

--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -173,6 +173,7 @@ export default function TouchDiagnosticsOverlay() {
       if (++tickCountRef.current >= Math.round(1000 / POLL_MS)) {
         tickCountRef.current = 0;
         const base = secRef.current;
+        const dStart = cur.touchstart - base.touchstart;
         const dMove = cur.touchmove - base.touchmove;
         const dDoc = cur.docTouchmove - base.docTouchmove;
         const dPtr = cur.docPointermove - base.docPointermove;
@@ -181,11 +182,16 @@ export default function TouchDiagnosticsOverlay() {
         // touch-delivery latency — the trend that should climb before the freeze.
         const latMax = Math.round(cur.moveLatencyMax);
         diag.moveLatencyMax = 0;
-        if (dMove > 0 || dDoc > 0 || dPtr > 0 || state?.drawing) {
+        // Gate on dStart too: rapid short taps (touchstart→touchend, no move) are
+        // exactly the 664108-class freeze trigger, but produce no move/pointer
+        // delta and may sample state.drawing=false between contacts. Without this
+        // those seconds would log nothing now that per-stroke start/end events
+        // are suppressed, losing the very rate `start` is meant to carry.
+        if (dStart > 0 || dMove > 0 || dDoc > 0 || dPtr > 0 || state?.drawing) {
           logEvent('tick', {
             // Per-second stroke-start count: per-stroke `start` logging is now
             // suppressed in DrawingCanvas, so the tick carries the rate instead.
-            start: cur.touchstart - base.touchstart,
+            start: dStart,
             move: dMove, doc: dDoc,
             onCanvas: cur.docTouchOnCanvas - base.docTouchOnCanvas,
             append: cur.appendOk - base.appendOk,


### PR DESCRIPTION
## 背景

直近の実機キャプチャ（非passive 現行 main、150秒連続短ストローク連打 → 約9.6秒フリーズ → 自己復帰）で、計測ハーネス自体の2つの弱点が顕在化した:

1. **ログがすぐ流れて長い時間軸が残らない** — `start`（毎タッチ開始）/ `touchend`（毎タッチ終了）が1ストロークごとに記録され、短ストローク連打では200件リングを数十秒で埋め尽くしフリーズ証跡を押し流す（実際「2回起きたが手前の1回はログから消えた」）。1Hz `tick` が圧縮済みタイムラインの役割を既に担っている。
2. **HUD が視界で気になる** — `heartbeat` が毎フレーム単調増加（HUD 行・折りたたみバッジ・canvas 上 `#N`）し、桁が増えるたびバッジ幅が振動。フリーズ中に見たい情報が常時動く数字に埋もれる。

機序自体は確定済み（WebKit/iPadOS のページ全体入力配信停止）で、本 PR は**計測ハーネスのチューニングのみ**。本修正は含まない。全て `DIAG_ENABLED` ガード内 / `?diag=touch` 時のみ。

## 変更

- **DrawingCanvas**: 通常の単一 stylus の `start`/`touchend` の `logEvent` を抑制（カウンタは維持）。異常時のみ記録（非stylus = Pencil 誤分類容疑 / マルチタッチ / touchcancel）。`tick` に per-second の `start` 数を集約してレートは保持。→ 同じ200件で**約3分遡れる**。
- **canvas 上ハートビート**: `#番号` を削除し**動くドットのみ**に（提示確認は維持、単調増加の視界ノイズを除去）。`diag.heartbeat` カウンタは Copy 用に維持。
- **Overlay**: フリーズ中に赤 `▲ FROZEN (s)` を**ライブ表示**（復帰後の count では遅い）、`heartbeat` 行を削除、折りたたみバッジから heartbeat を除去し**状態ドット（赤/緑/灰）+固定幅 `frz`** に、`tabular-nums` で桁変動による**幅振動を解消**。
- **テスト**: 通常 stylus stroke で start/touchend カウンタは増えるが `'start'`/`'touchend'` ログが出ないこと、非stylus start は `'start'` ログが出続けることを追加検証。

## 検証

- `npm run lint` / `npm run test`（587 passed）/ `npm run build` 全て通過。
- 実機（iPad `?diag=touch`）で: 長時間連続描画で `tick` が約3分遡れ毎ストローク行が消えていること、フリーズ中に `▲ FROZEN` 表示、復帰後 `freeze` がログに残り流れ去らないこと、バッジ/HUD の幅が振動しないこと、canvas 左上がドットのみで動くことを確認予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compresses touch diagnostics logging to keep ~3 minutes of history in the 200-entry ring and stabilizes the HUD to reduce visual noise, width jitter, and row jumps. Applies only when `DIAG_ENABLED` and `?diag=touch`.

- **Bug Fixes**
  - Suppress per-stroke `start`/`touchend` logs for normal single-stylus strokes; keep counters and log only anomalies (non-stylus, multi-touch, `touchcancel`).
  - Aggregate per-second start counts on the 1 Hz `tick`; gate on start delta so short tap–only seconds still log and carry the rate.
  - Canvas heartbeat: remove `#N` text; keep the moving dot as the render liveness signal.
  - Overlay: live "FROZEN (s)" during freezes; remove heartbeat row; add state dot (red/green/gray), fixed-width `frz` label, and tabular numerals — plus single-line rows (nowrap + ellipsis) — to eliminate width and row-height jitter.
  - Tests: verify suppression for stylus strokes and continued logging for non-stylus starts.
  - Outcome: freeze trails are retained under rapid short-stroke bursts.

<sup>Written for commit 265355479d4ee39e7be55b7a7fabc1f8a20118cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

