### PR TITLE
feat(diag): 未クローズ接触数 (open=touchstart−touchend) を計測

### DIFF
--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -143,14 +143,17 @@ export default function TouchDiagnosticsOverlay() {
           const durationMs = Math.round(now - freezeOnsetAtRef.current);
           diag.freezeCount++;
           diag.lastFreezeMs = durationMs;
-          // `open` = touchstart − touchend = contacts started but never ended
-          // (lost-touchend / 664108 hypothesis: an orphaned contact makes WebKit
-          // believe the Pencil is still down → exclusive input lock). `active` =
+          // `open` = touchstart − touchend − touchcancel = contacts started but
+          // neither ended nor canceled (lost-touchend / 664108 hypothesis: an
+          // orphaned contact makes WebKit believe the Pencil is still down →
+          // exclusive input lock). touchcancel must be subtracted — a canceled
+          // touch DID close (it just routes to the touchcancel counter, not
+          // touchend), so omitting it would misreport it as unclosed. `active` =
           // the canvas's own live-touch count. A healthy session pairs perfectly
           // (open oscillates 0↔1); open ≥ 1 lingering at recovery is the tell.
           logEvent('freeze', {
             durationMs, preStreakMs: Math.round(freezePreStreakRef.current),
-            open: cur.touchstart - cur.touchend, active: state?.activeTouchCount,
+            open: cur.touchstart - cur.touchend - cur.touchcancel, active: state?.activeTouchCount,
           });
           persistLog();
           inFreezeRef.current = false;
@@ -171,7 +174,7 @@ export default function TouchDiagnosticsOverlay() {
         // at the instant input went silent? See the `freeze` log comment.
         logEvent('freezeOnset', {
           preStreakMs: Math.round(cur.drawStreakMs),
-          open: cur.touchstart - cur.touchend, active: state?.activeTouchCount,
+          open: cur.touchstart - cur.touchend - cur.touchcancel, active: state?.activeTouchCount,
         });
         persistLog();
       }
@@ -212,11 +215,12 @@ export default function TouchDiagnosticsOverlay() {
             raf: cur.rafTick - base.rafTick,
             ptr: dPtr, pen: dPen,
             latMax,
-            // Running unclosed-contact count at the end of this second. In a
+            // Running unclosed-contact count at the end of this second (canceled
+            // touches subtracted — they close via the touchcancel counter). In a
             // healthy session this is 0 (between strokes) or 1 (mid-stroke); a
             // value that creeps up / never returns to 0 flags a lost touchend —
             // the suspected 664108 trigger — in the run-up to a freeze.
-            open: cur.touchstart - cur.touchend,
+            open: cur.touchstart - cur.touchend - cur.touchcancel,
             mode: state?.mode,
           });
         }
@@ -341,10 +345,10 @@ export default function TouchDiagnosticsOverlay() {
         {row('draw streak (s) / max', `${(c.drawStreakMs / 1000).toFixed(1)} / ${(c.maxDrawStreakMs / 1000).toFixed(1)}`)}
         {row('freezes / last (ms)', `${c.freezeCount} / ${c.lastFreezeMs}`, c.freezeCount > 0 ? '#f66' : '#9f9')}
         {row('mode / draw', s ? `${s.mode} / ${s.drawing}` : '?')}
-        {/* open = touchstart − touchend (unclosed contacts). >1 is anomalous —
-            the lost-touchend / exclusive-lock suspect. active = canvas live touches. */}
-        {row('open / active', `${c.touchstart - c.touchend} / ${s ? s.activeTouchCount : '?'}`,
-          (c.touchstart - c.touchend) > 1 ? '#f66' : undefined)}
+        {/* open = touchstart − touchend − touchcancel (unclosed contacts). >1 is
+            anomalous — the lost-touchend / exclusive-lock suspect. active = canvas live touches. */}
+        {row('open / active', `${c.touchstart - c.touchend - c.touchcancel} / ${s ? s.activeTouchCount : '?'}`,
+          (c.touchstart - c.touchend - c.touchcancel) > 1 ? '#f66' : undefined)}
         {row('last redraw / rAF (ms)', `${redrawAge} / ${rafAge}`,
           (redrawAge > REDRAW_STALL_MS || rafAge > RAF_STALL_MS) ? '#f66' : undefined)}
       </Box>

--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -143,7 +143,15 @@ export default function TouchDiagnosticsOverlay() {
           const durationMs = Math.round(now - freezeOnsetAtRef.current);
           diag.freezeCount++;
           diag.lastFreezeMs = durationMs;
-          logEvent('freeze', { durationMs, preStreakMs: Math.round(freezePreStreakRef.current) });
+          // `open` = touchstart − touchend = contacts started but never ended
+          // (lost-touchend / 664108 hypothesis: an orphaned contact makes WebKit
+          // believe the Pencil is still down → exclusive input lock). `active` =
+          // the canvas's own live-touch count. A healthy session pairs perfectly
+          // (open oscillates 0↔1); open ≥ 1 lingering at recovery is the tell.
+          logEvent('freeze', {
+            durationMs, preStreakMs: Math.round(freezePreStreakRef.current),
+            open: cur.touchstart - cur.touchend, active: state?.activeTouchCount,
+          });
           persistLog();
           inFreezeRef.current = false;
         }
@@ -159,7 +167,12 @@ export default function TouchDiagnosticsOverlay() {
         inFreezeRef.current = true;
         freezeOnsetAtRef.current = lastInputAtRef.current;
         freezePreStreakRef.current = cur.drawStreakMs;
-        logEvent('freezeOnset', { preStreakMs: Math.round(cur.drawStreakMs) });
+        // open/active at onset: was there an orphaned contact (lost touchend)
+        // at the instant input went silent? See the `freeze` log comment.
+        logEvent('freezeOnset', {
+          preStreakMs: Math.round(cur.drawStreakMs),
+          open: cur.touchstart - cur.touchend, active: state?.activeTouchCount,
+        });
         persistLog();
       }
 
@@ -199,6 +212,11 @@ export default function TouchDiagnosticsOverlay() {
             raf: cur.rafTick - base.rafTick,
             ptr: dPtr, pen: dPen,
             latMax,
+            // Running unclosed-contact count at the end of this second. In a
+            // healthy session this is 0 (between strokes) or 1 (mid-stroke); a
+            // value that creeps up / never returns to 0 flags a lost touchend —
+            // the suspected 664108 trigger — in the run-up to a freeze.
+            open: cur.touchstart - cur.touchend,
             mode: state?.mode,
           });
         }
@@ -323,6 +341,10 @@ export default function TouchDiagnosticsOverlay() {
         {row('draw streak (s) / max', `${(c.drawStreakMs / 1000).toFixed(1)} / ${(c.maxDrawStreakMs / 1000).toFixed(1)}`)}
         {row('freezes / last (ms)', `${c.freezeCount} / ${c.lastFreezeMs}`, c.freezeCount > 0 ? '#f66' : '#9f9')}
         {row('mode / draw', s ? `${s.mode} / ${s.drawing}` : '?')}
+        {/* open = touchstart − touchend (unclosed contacts). >1 is anomalous —
+            the lost-touchend / exclusive-lock suspect. active = canvas live touches. */}
+        {row('open / active', `${c.touchstart - c.touchend} / ${s ? s.activeTouchCount : '?'}`,
+          (c.touchstart - c.touchend) > 1 ? '#f66' : undefined)}
         {row('last redraw / rAF (ms)', `${redrawAge} / ${rafAge}`,
           (redrawAge > REDRAW_STALL_MS || rafAge > RAF_STALL_MS) ? '#f66' : undefined)}
       </Box>


### PR DESCRIPTION
## 背景

8分45秒（連続ストリーク525秒）の実機キャプチャでフリーズが**無発生**だった。このクリーンなログで `touchstart 1827 == touchend 1827`（完全にペア）・`touchcancel 0` ＝ **開いたまま閉じない接触がゼロ**だった点が、既知バグ **WebKit 664108**（`touchend` が1つロスト → Pencil 接触中と誤認 → 排他ロック → 全入力停止）の有力な足場になる。

→ 次回フリーズ時に「onset 直前/時点で孤立接触（lost touchend）があるか」を直接検証する計測を追加する。

機序確定のための**計測のみ**（本修正は含まない）。`DIAG_ENABLED` ガード内 / `?diag=touch` 時のみ。

## 変更

`open` = **`touchstart − touchend − touchcancel`** ＝ 開始したが ended でも canceled でもない未クローズ接触数。`touchcancel` は `touchend` ではなく `touchcancel` カウンタに入る（キャンセルされた接触も「閉じた」扱い）ため差し引く。

- **tick**: 各秒末の `open` を記録。健全時は 0↔1、creep up / 0 に戻らない＝lost touchend の兆候を run-up で可視化。
- **freezeOnset / freeze**: onset と復帰時の `open` と `active`（canvas が把握中のライブ接触数）をスナップショット記録。onset で `open ≥ 1` が張り付けば孤立接触＝機序確定。
- **HUD**: 「open / active」行を追加（`open > 1` を赤表示）。フリーズ中の張り付きを目視できる。

## 検証

- `npm run lint` / `npm run test`（587 passed）/ `npm run build` 全通過。
- 実機（iPad `?diag=touch`）で: 通常描画中 `open` が 0↔1 を往復すること、次回フリーズ発生時に `freezeOnset`/`freeze` の `open`/`active` を確認（孤立接触の有無で 664108 系仮説を判定）。

## レビュー対応

- **Cubic (P2)**: `open` の計算から `touchcancel` を除外（キャンセル接触の未クローズ誤計上を防止）。tick / freezeOnset / freeze / HUD の4箇所に反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)