### PR TITLE
feat(diag): フリーズ中の rAF/redraw 生存を記録する during-freeze tick

### DIFF
--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -203,8 +203,14 @@ export default function TouchDiagnosticsOverlay() {
         // delta and may sample state.drawing=false between contacts. Without this
         // those seconds would log nothing now that per-stroke start/end events
         // are suppressed, losing the very rate `start` is meant to carry.
-        if (dStart > 0 || dMove > 0 || dDoc > 0 || dPtr > 0 || state?.drawing) {
-          logEvent('tick', {
+        // Emit during a detected freeze too (`|| inFreezeRef.current`), bypassing
+        // the input-activity gate. Input is silent during a freeze so the normal
+        // gate logs nothing — leaving us blind to whether rAF/redraw keep running
+        // *inside* the freeze. With `frozen:1` + `sinceRaf`, the during-freeze
+        // ticks settle "input-only suspension (raf keeps ~60)" vs "rAF/main-thread
+        // death (raf→0, sinceRaf climbs)".
+        if (dStart > 0 || dMove > 0 || dDoc > 0 || dPtr > 0 || state?.drawing || inFreezeRef.current) {
+          const detail: Record<string, unknown> = {
             // Per-second stroke-start count: per-stroke `start` logging is now
             // suppressed in DrawingCanvas, so the tick carries the rate instead.
             start: dStart,
@@ -222,7 +228,14 @@ export default function TouchDiagnosticsOverlay() {
             // the suspected 664108 trigger — in the run-up to a freeze.
             open: cur.touchstart - cur.touchend - cur.touchcancel,
             mode: state?.mode,
-          });
+          };
+          if (inFreezeRef.current) {
+            // The decisive fields while frozen: is rAF still ticking (raf ~60 vs
+            // 0) and how stale is the last rAF callback?
+            detail.frozen = 1;
+            detail.sinceRaf = Math.round(now - cur.lastRafAt);
+          }
+          logEvent('tick', detail);
         }
         secRef.current = { ...cur };
       }

--- a/src/components/TouchDiagnosticsOverlay.tsx
+++ b/src/components/TouchDiagnosticsOverlay.tsx
@@ -35,6 +35,10 @@ const RAF_STALL_MS = 500;
 // the streak floor avoids flagging an idle-at-rest as a freeze.
 const FREEZE_GAP_MS = 1500;
 const FREEZE_MIN_STREAK_MS = 2000;
+// How long into a detected freeze to keep emitting the unconditional 1Hz tick
+// (rAF-liveness probe). The raf-alive verdict settles in a few seconds; bounding
+// it keeps a minutes-long freeze from overwriting the 200-entry ring's run-up.
+const FREEZE_LOG_WINDOW_MS = 30000;
 
 interface Snapshot {
   counters: typeof diag;
@@ -203,13 +207,20 @@ export default function TouchDiagnosticsOverlay() {
         // delta and may sample state.drawing=false between contacts. Without this
         // those seconds would log nothing now that per-stroke start/end events
         // are suppressed, losing the very rate `start` is meant to carry.
-        // Emit during a detected freeze too (`|| inFreezeRef.current`), bypassing
-        // the input-activity gate. Input is silent during a freeze so the normal
-        // gate logs nothing — leaving us blind to whether rAF/redraw keep running
-        // *inside* the freeze. With `frozen:1` + `sinceRaf`, the during-freeze
-        // ticks settle "input-only suspension (raf keeps ~60)" vs "rAF/main-thread
-        // death (raf→0, sinceRaf climbs)".
-        if (dStart > 0 || dMove > 0 || dDoc > 0 || dPtr > 0 || state?.drawing || inFreezeRef.current) {
+        // Emit during a detected freeze too, bypassing the input-activity gate.
+        // Input is silent during a freeze so the normal gate logs nothing —
+        // leaving us blind to whether rAF/redraw keep running *inside* the freeze.
+        // With `frozen:1` + `sinceRaf`, the during-freeze ticks settle "input-only
+        // suspension (raf keeps ~60)" vs "rAF/main-thread death (raf→0, sinceRaf
+        // climbs)". Capped to the first FREEZE_LOG_WINDOW_MS of the episode: the
+        // raf-alive verdict is settled within a few seconds, and an unbounded 1Hz
+        // emission would overwrite the 200-entry ring (losing the run-up and the
+        // freezeOnset entry) if a freeze persisted for minutes. Recovery is still
+        // captured by the `freeze` event, and a late rAF death by the rafStalled
+        // watchdog, regardless of this window.
+        const frozenLogging = inFreezeRef.current
+          && (now - freezeOnsetAtRef.current) < FREEZE_LOG_WINDOW_MS;
+        if (dStart > 0 || dMove > 0 || dDoc > 0 || dPtr > 0 || state?.drawing || frozenLogging) {
           const detail: Record<string, unknown> = {
             // Per-second stroke-start count: per-stroke `start` logging is now
             // suppressed in DrawingCanvas, so the tick carries the rate instead.
@@ -229,11 +240,13 @@ export default function TouchDiagnosticsOverlay() {
             open: cur.touchstart - cur.touchend - cur.touchcancel,
             mode: state?.mode,
           };
-          if (inFreezeRef.current) {
+          if (frozenLogging) {
             // The decisive fields while frozen: is rAF still ticking (raf ~60 vs
-            // 0) and how stale is the last rAF callback?
+            // 0) and how stale is the last rAF callback? Guard lastRafAt: a reset
+            // (overlay recovery / manual) zeroes it, which would otherwise report
+            // sinceRaf ≈ now. -1 = "no rAF timestamp yet", matching rafAge below.
             detail.frozen = 1;
-            detail.sinceRaf = Math.round(now - cur.lastRafAt);
+            detail.sinceRaf = cur.lastRafAt > 0 ? Math.round(now - cur.lastRafAt) : -1;
           }
           logEvent('tick', detail);
         }


### PR DESCRIPTION
## 背景

PR #212 の計測で**クリーンなフリーズを捕捉**できた。リロード後の単独 Pencil（palm 混入なし）で:

```
freezeOnset {"preStreakMs":63115,"open":0,"active":0}
```

onset 時点で `active:0`（canvas が把握中のライブ接触数ゼロ）・`open:0` ＝ **孤立接触なし** → **lost-touchend 仮説（touchend ロスト→接触中と誤認→排他ロック）は我々の観測層では反証**。

残った盲点: `tick` は「入力があった秒」しかログしないため、フリーズ**中**の `rafTick`/`redraw` 生存が一切記録されていない（ログは onset で終わる）。「入力のみ停止（rAF 生存）」なのか「rAF/メインスレッドごと停止」なのかを最終確定できていない。

## 変更

- `tick` の発火条件に `|| inFreezeRef.current` を追加。フリーズ検出中は入力ゲートを無視して ~1Hz で tick を出す。
- フリーズ中の tick には `frozen:1` と `sinceRaf`(= `now − lastRafAt`) を付与。
  - `raf` が ~60 を維持 → **入力のみ停止（rAF/メインスレッド生存）**。
  - `raf → 0` かつ `sinceRaf` 増大 → **rAF/メインスレッド死**。

計測のみ（本修正なし）。`DIAG_ENABLED` ガード内 / `?diag=touch` 時のみ。

## 検証

- `npm run lint` / `npm run test`（587 passed）/ `npm run build` 全通過。
- 実機（iPad `?diag=touch`）で次回フリーズ時、`frozen:1` の tick が onset 後も ~1Hz で出続け、`raf`/`sinceRaf` でフリーズ中の rAF 生存を判定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a during-freeze diagnostic tick to record rAF/redraw liveness and distinguish input-only freezes from main-thread stalls. Logging is diag-only (`DIAG_ENABLED` + `?diag=touch`) and limited to the first 30s of a freeze.

- **New Features**
  - Emit ~1 Hz ticks while a freeze is detected, bypassing the input gate and stopping after 30s.
  - Add `frozen: 1` and `sinceRaf` (ms since last rAF; `-1` if unknown) to show whether rAF stays ~60 or drops to 0.

<sup>Written for commit 5c542439134e32a7c0a72b8923eaa6bc1ad03671. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

