### PR TITLE
fix(ui): IME変換確定のEnterで送信されないようにする

### DIFF
--- a/src/components/PexelsSearcher.test.tsx
+++ b/src/components/PexelsSearcher.test.tsx
@@ -103,6 +103,25 @@ describe('PexelsSearcher search error feedback', () => {
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
+  it('does not run a search on an IME composition Enter', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ photos: [], next_page: null }), { status: 200 }),
+    );
+
+    render(<PexelsSearcher onSelectPhoto={vi.fn()} onApiKeyMissing={vi.fn()} />);
+    await waitFor(() => expect(getPexelsSearchHistoryMock).toHaveBeenCalled());
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'ポーズ' } });
+    // Enter while composing (typical Chrome/Firefox ordering).
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+    // Safari ordering: compositionend already delivered (isComposing false) but keyCode is 229.
+    fireEvent.keyDown(input, { key: 'Enter', keyCode: 229 });
+
+    await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument());
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it('does not surface an Alert when fetch succeeds', async () => {
     const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ photos: [], next_page: null }), { status: 200 }),

--- a/src/components/PexelsSearcher.tsx
+++ b/src/components/PexelsSearcher.tsx
@@ -38,6 +38,7 @@ import type { ReferenceInfo } from '../types';
 import { t } from '../i18n';
 import { ToolbarTooltip } from './ToolbarTooltip';
 import { resetPageZoom } from '../utils/resetPageZoom';
+import { isSubmitEnter } from '../utils/imeSafeEnter';
 
 /** Config payload for starting a gesture-drawing session from the search
  *  results. The parent shuffles + drives the session via useGestureSession. */
@@ -340,7 +341,7 @@ export function PexelsSearcher({ onSelectPhoto, onApiKeyMissing, active = true, 
               size="small"
               placeholder={t('pexelsSearchPlaceholder')}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.nativeEvent.isComposing && query.trim()) {
+                if (isSubmitEnter(e) && query.trim()) {
                   e.preventDefault();
                   void runSearch(query, orientation);
                 }

--- a/src/components/PexelsSearcher.tsx
+++ b/src/components/PexelsSearcher.tsx
@@ -340,7 +340,7 @@ export function PexelsSearcher({ onSelectPhoto, onApiKeyMissing, active = true, 
               size="small"
               placeholder={t('pexelsSearchPlaceholder')}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && query.trim()) {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing && query.trim()) {
                   e.preventDefault();
                   void runSearch(query, orientation);
                 }

--- a/src/components/PoseSourcePanel.tsx
+++ b/src/components/PoseSourcePanel.tsx
@@ -8,6 +8,7 @@ import { PoseParseError } from '../pose/poseTypes';
 import { DEFAULT_VRM_ID, USER_VRM_ID } from '../pose/bundledVrms';
 import { anthropicErrorDetail, generatePose, getAnthropicApiKey, isAnthropicAuthError, mapAnthropicErrorKey } from '../utils/anthropic';
 import { isAbortError } from '../utils/pexels';
+import { isSubmitEnter } from '../utils/imeSafeEnter';
 import { getUserVrm, saveUserVrm, VrmTooLargeError } from '../storage';
 import PoseViewer, { type PoseViewerActions, type PoseVrmSource } from './PoseViewer';
 import { PoseSketchPad, type PoseSketchPadHandle } from './PoseSketchPad';
@@ -308,7 +309,7 @@ export default function PoseSourcePanel({
             placeholder={t('poseHintPlaceholder')}
             value={hint}
             onChange={e => setHint(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter' && !e.nativeEvent.isComposing && !generating) handleGenerate(); }}
+            onKeyDown={(e) => { if (isSubmitEnter(e) && !generating) handleGenerate(); }}
             fullWidth
           />
           <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>

--- a/src/components/PoseSourcePanel.tsx
+++ b/src/components/PoseSourcePanel.tsx
@@ -308,7 +308,7 @@ export default function PoseSourcePanel({
             placeholder={t('poseHintPlaceholder')}
             value={hint}
             onChange={e => setHint(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter' && !generating) handleGenerate(); }}
+            onKeyDown={(e) => { if (e.key === 'Enter' && !e.nativeEvent.isComposing && !generating) handleGenerate(); }}
             fullWidth
           />
           <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>

--- a/src/utils/imeSafeEnter.test.ts
+++ b/src/utils/imeSafeEnter.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import type { KeyboardEvent } from 'react';
+import { isSubmitEnter } from './imeSafeEnter';
+
+function makeEvent(key: string, opts: { isComposing?: boolean; keyCode?: number } = {}): KeyboardEvent {
+  return {
+    key,
+    nativeEvent: {
+      isComposing: opts.isComposing ?? false,
+      keyCode: opts.keyCode ?? (key === 'Enter' ? 13 : 0),
+    },
+  } as unknown as KeyboardEvent;
+}
+
+describe('isSubmitEnter', () => {
+  it('accepts a plain Enter', () => {
+    expect(isSubmitEnter(makeEvent('Enter'))).toBe(true);
+  });
+
+  it('rejects non-Enter keys', () => {
+    expect(isSubmitEnter(makeEvent('a'))).toBe(false);
+  });
+
+  it('rejects Enter during IME composition (isComposing)', () => {
+    expect(isSubmitEnter(makeEvent('Enter', { isComposing: true }))).toBe(false);
+  });
+
+  it('rejects the Safari IME-confirm Enter (isComposing false but keyCode 229)', () => {
+    expect(isSubmitEnter(makeEvent('Enter', { isComposing: false, keyCode: 229 }))).toBe(false);
+  });
+});

--- a/src/utils/imeSafeEnter.ts
+++ b/src/utils/imeSafeEnter.ts
@@ -1,0 +1,11 @@
+import type { KeyboardEvent } from 'react';
+
+/**
+ * True when an Enter keydown is a real submit, not an IME composition confirm.
+ * `isComposing` alone is insufficient: Safari delivers `compositionend` before
+ * the final keydown, so that keydown reports `isComposing === false` — but it
+ * still carries the legacy IME keyCode 229, which is the remaining signal.
+ */
+export function isSubmitEnter(e: KeyboardEvent): boolean {
+  return e.key === 'Enter' && !e.nativeEvent.isComposing && e.nativeEvent.keyCode !== 229;
+}


### PR DESCRIPTION
## 概要

日本語入力(IME)の変換確定Enterが送信として扱われてしまう問題を修正。

- `PoseSourcePanel` のヒント入力欄: 変換確定のEnterでポーズ生成が実行されてしまっていた
- `PexelsSearcher` の検索欄: 同パターンのため予防的に同修正を適用

`e.nativeEvent.isComposing` が `true`(変換中)の間はEnterを無視するようにした。

APIキーダイアログやURL入力欄のEnterハンドラはIMEで入力する内容ではないため対象外(SketchfabのAutocompleteはMUI内部で変換中Enterを弾き済み)。

## テスト

- `npm run lint` ✅
- `npm run test` ✅ (44 files / 667 tests passed)
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized keyboard-handling change with tests; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes **Enter during Japanese IME composition** accidentally triggering pose generation or Pexels search when users only meant to confirm a conversion.
> 
> Adds shared helper **`isSubmitEnter`**, which treats Enter as submit only when `nativeEvent.isComposing` is false **and** `keyCode !== 229` (Safari can fire the confirm Enter after `compositionend`, so `isComposing` alone is not enough). **`PoseSourcePanel`** hint field and **`PexelsSearcher`** search field now use this instead of a bare `e.key === 'Enter'` check.
> 
> Unit tests cover the helper; **`PexelsSearcher`** gets a test that IME-style Enter does not call `fetch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 234f4fffa86cc19a840bfa9f1bb5b2896b1743ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop treating IME composition Enter as submit in the pose hint and Pexels search fields. Japanese input can be confirmed without triggering generate or search, including on Safari.

- **Bug Fixes**
  - Use `isSubmitEnter` to ignore IME confirm Enter (`isComposing` or keyCode 229) in the pose hint input and Pexels search input.
  - API key and URL inputs are unchanged; Sketchfab autocomplete already handles IME Enter.

<sup>Written for commit 234f4fffa86cc19a840bfa9f1bb5b2896b1743ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

