### PR TITLE
fix(pose): 生成完了時にヒント欄の下書きを巻き戻さない

### DIFF
--- a/src/components/PoseSourcePanel.tsx
+++ b/src/components/PoseSourcePanel.tsx
@@ -85,7 +85,13 @@ export default function PoseSourcePanel({
   const [prevPoseInfo, setPrevPoseInfo] = useState(poseInfo);
   if (prevPoseInfo !== poseInfo) {
     setPrevPoseInfo(poseInfo);
-    if (poseInfo && poseInfo !== selfCommitted) {
+    if (poseInfo && poseInfo === selfCommitted) {
+      // One-shot: only the immediate post-commit swap skips. Undo history
+      // restores the SAME object instance, so without clearing, redo back to
+      // this pose would also skip and keep a stale hint/model toggle.
+      setSelfCommitted(null);
+    }
+    else if (poseInfo) {
       setHint(poseInfo.hint ?? '');
       setVrmId(poseInfo.vrmId);
     }
@@ -177,7 +183,7 @@ export default function PoseSourcePanel({
         // abort lands) — never let a stale pose overwrite a newer one, and
         // never apply after unmount.
         if (controller.signal.aborted || abortRef.current !== controller) return;
-        const info = {
+        const info: NonNullable<PoseSourcePanelProps['poseInfo']> = {
           source: 'pose',
           // hint/title deliberately stay the REQUEST-time values — they
           // describe the pose that was generated, not the textbox draft.
@@ -186,7 +192,7 @@ export default function PoseSourcePanel({
           vrmId: vrmIdRef.current,
           pose: generated,
           hint: hint.trim() || undefined,
-        } as const;
+        };
         setSelfCommitted(info);
         onReferenceChange((s) => {
           s.setReferenceInfo(info);

--- a/src/components/PoseSourcePanel.tsx
+++ b/src/components/PoseSourcePanel.tsx
@@ -76,11 +76,16 @@ export default function PoseSourcePanel({
   // (same pattern as ReferencePanel's YouTube state reset). Detect by object
   // identity, NOT referenceKey — the key deliberately excludes hint (and
   // imageUrl), so two infos differing only there would be missed, while every
-  // external swap necessarily supplies a different object.
+  // external swap necessarily supplies a different object. Our OWN generation
+  // commit also swaps poseInfo but must NOT re-seed: the user may already be
+  // typing the next hint while the refinement rounds run, and re-seeding
+  // would revert the field to the request-time text — the commit remembers
+  // its info object (state, so it is render-safe) and is skipped here.
+  const [selfCommitted, setSelfCommitted] = useState<PoseSourcePanelProps['poseInfo']>(null);
   const [prevPoseInfo, setPrevPoseInfo] = useState(poseInfo);
   if (prevPoseInfo !== poseInfo) {
     setPrevPoseInfo(poseInfo);
-    if (poseInfo) {
+    if (poseInfo && poseInfo !== selfCommitted) {
       setHint(poseInfo.hint ?? '');
       setVrmId(poseInfo.vrmId);
     }
@@ -172,17 +177,19 @@ export default function PoseSourcePanel({
         // abort lands) — never let a stale pose overwrite a newer one, and
         // never apply after unmount.
         if (controller.signal.aborted || abortRef.current !== controller) return;
+        const info = {
+          source: 'pose',
+          // hint/title deliberately stay the REQUEST-time values — they
+          // describe the pose that was generated, not the textbox draft.
+          title: hint.trim() || t('pose'),
+          author: '',
+          vrmId: vrmIdRef.current,
+          pose: generated,
+          hint: hint.trim() || undefined,
+        } as const;
+        setSelfCommitted(info);
         onReferenceChange((s) => {
-          s.setReferenceInfo({
-            source: 'pose',
-            // hint/title deliberately stay the REQUEST-time values — they
-            // describe the pose that was generated, not the textbox draft.
-            title: hint.trim() || t('pose'),
-            author: '',
-            vrmId: vrmIdRef.current,
-            pose: generated,
-            hint: hint.trim() || undefined,
-          });
+          s.setReferenceInfo(info);
         });
         committed = true;
       })


### PR DESCRIPTION
## 問題

ポーズ生成の調整ラウンド(「調整中…」、数十秒)の間に次に試したいヒントを入力していると、生成完了時にテキストがリクエスト時の値へ巻き戻される。

**原因**: 生成完了のコミットが新しい `poseInfo` を書き込み、それが「undo/gallery など外部からの poseInfo 差し替え時にヒント欄・モデルトグルを再シードする」レンダ時 prev 比較(オブジェクト同一性検知)を自コミットでも発火させていた。

## 対応

コミット直前に自分の info オブジェクトを state(`selfCommitted`)へ記憶し、レンダ時比較で `poseInfo === selfCommitted` の場合は再シードをスキップ。外部 swap は必ず別オブジェクトを供給するので従来通り再シードされる。ref フラグ案は `react-hooks/refs`(render 中の ref アクセス禁止)に抵触するため state 方式を採用。

保存される `referenceInfo.hint`/`title` は従来通り「生成に使ったリクエスト時の値」のまま — 保護されるのはテキストボックスの下書きのみ。

## テスト

- 731 件通過(PoseSourcePanel は three.js を抱える lazy チャンクでコンポーネントテスト対象外)
- 実機確認済み: 調整中に入力した下書きが完了後も保持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wgPUwsagy6qRN6AMAN9on

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the hint input from reverting to the request-time value when pose generation completes. Users can type the next hint during refinement and their draft stays in the textbox; saved `referenceInfo.hint`/`title` stay at the request-time values.

- **Bug Fixes**
  - Track committed `poseInfo` in `selfCommitted` and skip reseeding on match; clear after use so undo/redo reseeds correctly.
  - External swaps (undo/gallery) still reseed as before.
  - Replace `as const` with `NonNullable<PoseSourcePanelProps['poseInfo']>` for the committed info.

<sup>Written for commit f473059b120e3aa4d3adf27ffa2a44d027c55f94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

