### PR TITLE
docs: clarify Anthropic key storage access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Read the relevant rule document before changing those areas. Keep `AGENTS.md` as
 - Pexels API keys are user-supplied and stored in `localStorage['pexelsApiKey']`; never bundle a key.
 - Local images and Sketchfab screenshots are stored in URL history so references can be restored later.
 - Trace template replacement / undo semantics are path-specific; read `trace-template.md` before changing template state, scoring, or bundled template behavior.
-- The `pose` source accepts a rough figure sketch and/or a text hint, calls the Anthropic Claude API directly from the browser using the user's `localStorage['anthropicApiKey']`, and applies semantic pose JSON to a three.js / three-vrm mannequin. Never bundle an API key.
+- The `pose` source accepts a rough figure sketch and/or a text hint, calls the Anthropic Claude API directly from the browser using the user's `localStorage.getItem('anthropicApiKey')` value, and applies semantic pose JSON to a three.js / three-vrm mannequin. Never bundle an API key.
 - Pose limbs may use angles or placement targets (`handAt`, `footAt`, `kneeAt`, `elbowAt`, and `body.hipsHeight`) solved by analytic two-bone IK. Generated poses are geometrically validated and may be refined in the same model conversation for at most two rounds.
 - Pose "Fix This Angle" uses the standard fixed-image path. User-loaded VRMs are stored in `poseAssets`; successful generations are stored in the capped, LRU-managed `poseHistory` and can be reapplied. Inverted-pose hair behavior is a VRM spring-bone model trait; see `docs/vrm-springbone-gravity.md`.
 


### PR DESCRIPTION
## Summary
- address the Copilot review left on #276
- document Anthropic API-key access using the same localStorage.getItem call as the implementation

## Validation
- npm run lint
- npm run build
- tests not run (documentation-only change)

Follow-up to #276.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Anthropic API key access in `AGENTS.md` to match the implementation: use `localStorage.getItem('anthropicApiKey')` for browser calls to Claude. This removes ambiguity and reiterates that keys are never bundled.

<sup>Written for commit a962c90a8ca2f356f6f7fa9d3c406f8c7ab86448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

