### PR TITLE
fix(pose): パース不能なモデル応答のテキストをエラー表示に含める

### DIFF
--- a/src/components/PoseSourcePanel.tsx
+++ b/src/components/PoseSourcePanel.tsx
@@ -40,6 +40,17 @@ interface PoseSourcePanelProps {
 const SKETCH_DISPLAY_SIZE = 160;
 /** Longest edge of the pose-history thumbnail JPEG (Blob in IndexedDB). */
 const POSE_HISTORY_THUMB_EDGE = 192;
+/**
+ * Cap for the model-reply excerpt shown in the error Alert. A refusal
+ * explanation fits well under this; a long analysis that merely failed to
+ * parse would otherwise flood the panel (the full text is in the console).
+ */
+const REPLY_DETAIL_MAX_CHARS = 400;
+
+function clipReplyText(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  return text.length > REPLY_DETAIL_MAX_CHARS ? `${text.slice(0, REPLY_DETAIL_MAX_CHARS)}…` : text;
+}
 
 /**
  * Browse-mode UI for the 'pose' reference source: stick-figure sketch pad +
@@ -187,6 +198,10 @@ export default function PoseSourcePanel({
         onRefineStart: () => setRefining(true),
         onRefineError: (e) => {
           if (controller.signal.aborted || abortRef.current !== controller) return;
+          if (e instanceof PoseParseError) {
+            setError({ message: t('posePoseParseError'), detail: clipReplyText(e.replyText), keyAction: false });
+            return;
+          }
           const key = mapAnthropicErrorKey(e);
           setError({ message: t(key), detail: anthropicErrorDetail(e), keyAction: isAnthropicAuthError(e) });
         },
@@ -235,7 +250,7 @@ export default function PoseSourcePanel({
         if (isAbortError(e)) return;
         if (controller.signal.aborted || abortRef.current !== controller) return;
         if (e instanceof PoseParseError) {
-          setError({ message: t('posePoseParseError'), keyAction: false });
+          setError({ message: t('posePoseParseError'), detail: clipReplyText(e.replyText), keyAction: false });
           return;
         }
         const key = mapAnthropicErrorKey(e);

--- a/src/pose/poseTypes.ts
+++ b/src/pose/poseTypes.ts
@@ -126,6 +126,13 @@ export interface PoseJson {
 }
 
 export class PoseParseError extends Error {
+  /**
+   * The model's raw reply text, attached by the API caller so the UI can show
+   * WHY no pose came back (e.g. a refusal explanation) — parsePoseJson itself
+   * only knows the text it was given, the caller owns the display decision.
+   */
+  replyText?: string;
+
   constructor(message: string) {
     super(message);
     this.name = 'PoseParseError';

--- a/src/utils/anthropic.test.ts
+++ b/src/utils/anthropic.test.ts
@@ -134,10 +134,12 @@ describe('generatePose', () => {
     );
   });
 
-  it('throws PoseParseError when the reply has no JSON', async () => {
+  it('throws PoseParseError carrying the reply text when the reply has no JSON', async () => {
     setAnthropicApiKey('sk-test');
     fetchMock.mockResolvedValueOnce(textResponse('I cannot see a figure.'));
-    await expect(generatePose('AAAA', '')).rejects.toBeInstanceOf(PoseParseError);
+    const err = await generatePose('AAAA', '').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(PoseParseError);
+    expect((err as PoseParseError).replyText).toBe('I cannot see a figure.');
   });
 
   it('surfaces the API error message as detail on HTTP errors', async () => {

--- a/src/utils/anthropic.ts
+++ b/src/utils/anthropic.ts
@@ -265,6 +265,10 @@ async function requestPose(messages: AnthropicMessage[], signal?: AbortSignal): 
       // (no text block at all — e.g. an empty/refused completion), so log
       // the whole response body too.
       console.error('[pose] unparsable model reply:', text || '(no text block)', data);
+      // A JSON-less reply is usually the model explaining itself (e.g. a
+      // refusal) — carry the text to the UI so the user sees the reason
+      // without opening the console.
+      if (text) e.replyText = text;
     }
     throw e;
   }


### PR DESCRIPTION
## 概要

ポーズ生成でモデルがJSONを返さず説明文（例: 不適切な内容への拒否理由）だけを返した場合、その理由がconsoleにしか出力されず、UIには汎用の「ポーズの解析に失敗しました」しか表示されなかった問題の改善。

## 変更内容

- `PoseParseError` に `replyText` フィールドを追加し、`anthropic.ts` のパース失敗時にモデルの応答テキストを添付
- `PoseSourcePanel` の初回生成と refine ループ両方の捕捉箇所で、`replyText` を `error.detail` として渡し、既存のAPIエラー詳細と同じ monospace 表示に載せる
- 長い応答がパネルを埋めないよう400文字で切り詰め（全文は従来どおり console に残る）
- 副次修正: refine 中のパース失敗が `mapAnthropicErrorKey` 経由で「ネットワークエラー」と誤表示されていた点を修正

## テスト

- `npm run lint` ✅
- `npm run build` ✅
- `npm run test` 全766件パス ✅（`replyText` が付与されることを検証するテストを追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the model’s reply text when pose generation returns no JSON, so users see the refusal/explanation instead of a generic parse error. Also fixes refine-loop parse errors that were shown as “network error.”

- **Bug Fixes**
  - Add `replyText` to `PoseParseError` and set it in `anthropic.ts` when the reply lacks JSON.
  - Display a clipped reply excerpt (400 chars) in `PoseSourcePanel` error details for both initial generation and refine; full text stays in the console.
  - Correct refine parse failures that were mislabelled as network errors.

<sup>Written for commit 761de29471a642253d96997c8b82e44a155728dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

