### PR TITLE
chore(deps-dev): npm audit fix で brace-expansion を 5.0.8 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2374,16 +2374,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {


### PR DESCRIPTION
## 概要

`npm audit` が報告していた high severity の脆弱性を `npm audit fix` で解消しました。

- **brace-expansion 5.0.7 → 5.0.8** (dev 依存の推移的依存)
- [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg): 無制限な展開長により OOM でプロセスがクラッシュする DoS

`package.json` の変更はなく、`package-lock.json` のみの更新です。

## 確認結果

- `npm audit`: **found 0 vulnerabilities**
- `npm run lint`: 成功
- `npm run test`: 49 files / 764 passed, 1 skipped
- `npm run build`: 成功

CLAUDE.md / README.md はアーキテクチャ・機能・コマンドに影響がないため更新なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated transitive dev dependency `brace-expansion` from 5.0.7 to 5.0.8 via npm audit fix to resolve a high-severity DoS advisory (GHSA-mh99-v99m-4gvg). Lockfile-only change; no `package.json` updates.

<sup>Written for commit a01ba3986db8999342774923371f4ca5fc7ebbdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

