### PR TITLE
feat(drawing): 全消去でカメラ(パン・ズーム)もホームに戻す

### DIFF
--- a/src/components/DrawingPanel.tsx
+++ b/src/components/DrawingPanel.tsx
@@ -247,6 +247,10 @@ export function DrawingPanel({
     // restore the elapsed time. A reset happens later iff the user commits
     // by drawing a new stroke (see handleStrokeCountChange).
     timer.pause();
+    // Clearing the canvas also returns the camera home: a blank canvas panned
+    // off to some corner at 3x zoom is disorienting, and the user's next stroke
+    // should start from the same view a fresh session would.
+    setViewResetVersion(v => v + 1);
     triggerRedraw({ flush: true });
     onOverlayClear?.();
   }, [strokeManager, triggerRedraw, timer, onOverlayClear, onTraceResetScores]);


### PR DESCRIPTION
## 概要

描画キャンバスのゴミ箱ボタン（全消去・タイマーリセット）を押したとき、ストロークだけでなくパン・ズーム状態もホーム（中心・等倍）に戻すようにしました。

これまでは拡大・スクロールしたままの空キャンバスが残り、次に描き始める位置が分かりにくい状態でした。

## 変更内容

- `DrawingPanel.handleClear` で `viewResetVersion` を bump
  - `DrawingCanvas` の既存リセットエフェクト経由で `viewTransform.userResetToHome()` が呼ばれる（リセットボタンと同じ経路）
  - 「消すものが無い」場合の早期 return より後に置いてあるので、無効クリックでカメラは動かない
- 既存の Undo 挙動（tentativeClear の巻き戻し）は変更なし。カメラ位置は Undo 対象ではないため、Undo してもカメラはホームのまま

## テスト

- `npm run lint` ✅
- `npm run build` ✅
- `npx vitest run src/components/DrawingPanel.test.tsx` ✅ 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clearing the canvas now also resets the camera (pan and zoom) to home (center, 1x) so the next stroke starts from a predictable view. No-op clears don’t move the camera, and undo still only restores strokes; the camera stays at home.

<sup>Written for commit a5aa3def86d42c78ee0d9cf0c89db9aef41198b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/koizuka/drawing-practice/pull/300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

